### PR TITLE
Include hashtags in post queries on profile pages

### DIFF
--- a/app/profile/ProfileClient.tsx
+++ b/app/profile/ProfileClient.tsx
@@ -117,9 +117,21 @@ export default function ProfileClient({ user, currentUser, posts, likedPosts = [
       </div>
 
       {activeTab === 'posts' ? (
-        <Feed key="posts" initialPosts={posts} currentUserId={currentUser?.id ?? -1} />
+        <Feed
+            key="posts"
+            initialPosts={posts}
+            currentUserId={currentUser?.id ?? -1}
+            feedType="user_posts"
+            targetUserId={user.id}
+        />
       ) : (
-        <Feed key="likes" initialPosts={likedPosts} currentUserId={currentUser?.id ?? -1} />
+        <Feed
+            key="likes"
+            initialPosts={likedPosts}
+            currentUserId={currentUser?.id ?? -1}
+            feedType="user_likes"
+            targetUserId={user.id}
+        />
       )}
 
       <VerificationModal 

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -41,6 +41,7 @@ export default async function ProfilePage() {
 
   // Fetch my posts
   const myPostsData = await db.post.findMany({
+    take: 12,
     where: { userId: session.id },
     orderBy: { createdAt: 'desc' },
     select: {
@@ -48,6 +49,11 @@ export default async function ProfilePage() {
       // imageUrl: true,
       comment: true,
       userId: true,
+      hashtags: {
+        select: {
+            name: true
+        }
+      },
       user: {
           select: {
               username: true,
@@ -79,6 +85,7 @@ export default async function ProfilePage() {
 
   // Fetch liked posts
   const likedPostsData = await db.like.findMany({
+      take: 12,
       where: { userId: session.id },
       orderBy: { createdAt: 'desc' },
       select: {
@@ -88,6 +95,11 @@ export default async function ProfilePage() {
                 // imageUrl: true,
                 comment: true,
                 userId: true,
+                hashtags: {
+                    select: {
+                        name: true
+                    }
+                },
                 user: {
                     select: {
                         username: true,

--- a/app/users/[username]/page.tsx
+++ b/app/users/[username]/page.tsx
@@ -66,6 +66,7 @@ export default async function UserPage({ params }: { params: Promise<{ username:
   }
 
   const postsData = await db.post.findMany({
+    take: 12,
     where: { userId: user.id },
     orderBy: { createdAt: 'desc' },
     select: {
@@ -73,6 +74,11 @@ export default async function UserPage({ params }: { params: Promise<{ username:
       // imageUrl: true,
       comment: true,
       userId: true,
+      hashtags: {
+        select: {
+            name: true
+        }
+      },
       user: {
           select: {
               username: true,
@@ -106,6 +112,7 @@ export default async function UserPage({ params }: { params: Promise<{ username:
   if (isMe) {
       // Fetch liked posts only if viewing own profile
       const likedPostsData = await db.like.findMany({
+          take: 12,
           where: { userId: user.id },
           orderBy: { createdAt: 'desc' },
           select: {
@@ -115,6 +122,11 @@ export default async function UserPage({ params }: { params: Promise<{ username:
                     // imageUrl: true,
                     comment: true,
                     userId: true,
+                hashtags: {
+                    select: {
+                        name: true
+                    }
+                },
                     user: {
                         select: {
                             username: true,


### PR DESCRIPTION
- Updated `app/profile/page.tsx` and `app/users/[username]/page.tsx` to select `hashtags` when fetching posts and liked posts.
- This ensures that hashtags are displayed in the post popup on profile pages, resolving the issue where they were missing.