### PR TITLE
Include comments in post queries on profile pages

### DIFF
--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -54,6 +54,20 @@ export default async function ProfilePage() {
             name: true
         }
       },
+      comments: {
+        select: {
+            id: true,
+            text: true,
+            userId: true,
+            user: {
+                select: {
+                    username: true,
+                    avatarUrl: true
+                }
+            }
+        },
+        orderBy: { createdAt: 'asc' }
+      },
       user: {
           select: {
               username: true,
@@ -99,6 +113,20 @@ export default async function ProfilePage() {
                     select: {
                         name: true
                     }
+                },
+                comments: {
+                    select: {
+                        id: true,
+                        text: true,
+                        userId: true,
+                        user: {
+                            select: {
+                                username: true,
+                                avatarUrl: true
+                            }
+                        }
+                    },
+                    orderBy: { createdAt: 'asc' }
                 },
                 user: {
                     select: {

--- a/app/users/[username]/page.tsx
+++ b/app/users/[username]/page.tsx
@@ -79,6 +79,20 @@ export default async function UserPage({ params }: { params: Promise<{ username:
             name: true
         }
       },
+      comments: {
+        select: {
+            id: true,
+            text: true,
+            userId: true,
+            user: {
+                select: {
+                    username: true,
+                    avatarUrl: true
+                }
+            }
+        },
+        orderBy: { createdAt: 'asc' }
+      },
       user: {
           select: {
               username: true,
@@ -126,6 +140,20 @@ export default async function UserPage({ params }: { params: Promise<{ username:
                     select: {
                         name: true
                     }
+                },
+                comments: {
+                    select: {
+                        id: true,
+                        text: true,
+                        userId: true,
+                        user: {
+                            select: {
+                                username: true,
+                                avatarUrl: true
+                            }
+                        }
+                    },
+                    orderBy: { createdAt: 'asc' }
                 },
                     user: {
                         select: {


### PR DESCRIPTION
- Updated `app/profile/page.tsx` and `app/users/[username]/page.tsx` to select `comments` when fetching posts and liked posts.
- This ensures that comments are displayed in the post popup on profile pages, resolving the issue where they were missing.