### PR TITLE
Fix Sakurafall & Snowfall animation loop bug

### DIFF
--- a/components/Sakurafall.tsx
+++ b/components/Sakurafall.tsx
@@ -18,6 +18,7 @@ interface Petal {
 
 export default function Sakurafall() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const animationFrameId = useRef<number | null>(null);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -26,9 +27,9 @@ export default function Sakurafall() {
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
 
-    let animationFrameId: number;
     let petals: Petal[] = [];
     let time = 0;
+    let lastTime = 0;
 
     const resizeCanvas = () => {
       canvas.width = window.innerWidth;
@@ -89,12 +90,12 @@ export default function Sakurafall() {
       });
     };
 
-    const update = () => {
-      time++;
+    const update = (deltaTimeScale: number) => {
+      time += 1 * deltaTimeScale;
       petals.forEach((petal) => {
-        petal.y += petal.speed;
-        petal.x += petal.wind;
-        petal.rotation += petal.rotationSpeed;
+        petal.y += petal.speed * deltaTimeScale;
+        petal.x += petal.wind * deltaTimeScale;
+        petal.rotation += petal.rotationSpeed * deltaTimeScale;
 
         // Reset if off screen
         if (petal.y > canvas.height + 20) {
@@ -109,22 +110,33 @@ export default function Sakurafall() {
       });
     };
 
-    const loop = () => {
+    const loop = (timestamp: number) => {
+      if (!lastTime) lastTime = timestamp;
+      const deltaTime = timestamp - lastTime;
+      lastTime = timestamp;
+
+      // Calculate scale factor relative to 60 FPS (approx 16.66ms per frame)
+      // Cap deltaTime at 50ms to prevent massive jumps if tab is inactive
+      const clampedDeltaTime = Math.min(deltaTime, 50);
+      const deltaTimeScale = clampedDeltaTime / 16.66;
+
       draw();
-      update();
-      animationFrameId = requestAnimationFrame(loop);
+      update(deltaTimeScale);
+      animationFrameId.current = requestAnimationFrame(loop);
     };
 
     // Initialize
     resizeCanvas();
     createPetals();
-    loop();
+    animationFrameId.current = requestAnimationFrame(loop);
 
     window.addEventListener("resize", resizeCanvas);
 
     return () => {
       window.removeEventListener("resize", resizeCanvas);
-      cancelAnimationFrame(animationFrameId);
+      if (animationFrameId.current !== null) {
+        cancelAnimationFrame(animationFrameId.current);
+      }
     };
   }, []);
 

--- a/components/Snowfall.tsx
+++ b/components/Snowfall.tsx
@@ -13,6 +13,7 @@ interface Snowflake {
 
 export default function Snowfall() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const animationFrameId = useRef<number | null>(null);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -21,8 +22,8 @@ export default function Snowfall() {
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
 
-    let animationFrameId: number;
     let snowflakes: Snowflake[] = [];
+    let lastTime = 0;
 
     const resizeCanvas = () => {
       canvas.width = window.innerWidth;
@@ -56,10 +57,10 @@ export default function Snowfall() {
       });
     };
 
-    const update = () => {
+    const update = (deltaTimeScale: number) => {
       snowflakes.forEach((flake) => {
-        flake.y += flake.speed;
-        flake.x += flake.wind;
+        flake.y += flake.speed * deltaTimeScale;
+        flake.x += flake.wind * deltaTimeScale;
 
         // Reset if off screen
         if (flake.y > canvas.height) {
@@ -74,22 +75,33 @@ export default function Snowfall() {
       });
     };
 
-    const loop = () => {
+    const loop = (timestamp: number) => {
+      if (!lastTime) lastTime = timestamp;
+      const deltaTime = timestamp - lastTime;
+      lastTime = timestamp;
+
+      // Calculate scale factor relative to 60 FPS (approx 16.66ms per frame)
+      // Cap deltaTime at 50ms to prevent massive jumps if tab is inactive
+      const clampedDeltaTime = Math.min(deltaTime, 50);
+      const deltaTimeScale = clampedDeltaTime / 16.66;
+
       draw();
-      update();
-      animationFrameId = requestAnimationFrame(loop);
+      update(deltaTimeScale);
+      animationFrameId.current = requestAnimationFrame(loop);
     };
 
     // Initialize
     resizeCanvas();
     createSnowflakes();
-    loop();
+    animationFrameId.current = requestAnimationFrame(loop);
 
     window.addEventListener("resize", resizeCanvas);
 
     return () => {
       window.removeEventListener("resize", resizeCanvas);
-      cancelAnimationFrame(animationFrameId);
+      if (animationFrameId.current !== null) {
+        cancelAnimationFrame(animationFrameId.current);
+      }
     };
   }, []);
 


### PR DESCRIPTION
This commit resolves an issue where the `Sakurafall` (and `Snowfall`) animation could exponentially speed up if the component unmounted and remounted rapidly, such as when opening and closing images. This happened because `animationFrameId` was stored as a local variable within `useEffect` instead of a `useRef`, which could cause old `requestAnimationFrame` loops to keep running if closures were invalidated. The `animationFrameId` is now tracked using a `useRef`, ensuring any existing loop is consistently cancelled upon cleanup.

Additionally, this commit implements delta-time based physics instead of fixed per-frame updates. This ensures that the petals and snowflakes fall at a constant, consistent real-world speed regardless of the device's screen refresh rate (e.g., 60Hz vs 120Hz ProMotion displays).

---
*PR created automatically by Jules for task [12594699656871551398](https://jules.google.com/task/12594699656871551398) started by @testuser0123-web*