### PR TITLE
Fix automatic logout bug by ensuring session refresh propagation

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -68,9 +68,15 @@ export async function updateSession(request: NextRequest) {
   // Only refresh if session expires in less than 3 days (to save CPU)
   // Current logic sets 1 week.
   const now = new Date();
-  const expiresAt = new Date(parsed.expires);
+  const expiresAt = parsed.expires
+    ? new Date(parsed.expires as string | number | Date)
+    : (parsed.exp ? new Date((parsed.exp as number) * 1000) : null);
 
-  // If expires is missing or close to expiry (within 3 days), refresh it
+  if (!expiresAt) {
+      return;
+  }
+
+  // If expires is close to expiry (within 3 days), refresh it
   const threeDays = 3 * 24 * 60 * 60 * 1000;
   if (expiresAt.getTime() - now.getTime() > threeDays) {
       return; // No need to update

--- a/middleware.ts
+++ b/middleware.ts
@@ -12,7 +12,7 @@ export async function middleware(request: NextRequest) {
   }
 
   // Update session expiry if exists
-  await updateSession(request);
+  const sessionRes = await updateSession(request);
 
   const session = request.cookies.get('session');
   const { pathname } = request.nextUrl;
@@ -20,9 +20,13 @@ export async function middleware(request: NextRequest) {
   // Public routes
   if (pathname === '/login' || pathname === '/signup') {
     if (session) {
-      return NextResponse.redirect(new URL('/', request.url));
+      const res = NextResponse.redirect(new URL('/', request.url));
+      if (sessionRes) {
+          res.cookies.set('session', sessionRes.cookies.get('session')?.value || '', sessionRes.cookies.get('session'));
+      }
+      return res;
     }
-    return NextResponse.next();
+    return sessionRes || NextResponse.next();
   }
 
   // Guest Allowed Routes
@@ -43,10 +47,13 @@ export async function middleware(request: NextRequest) {
     !pathname.startsWith('/_next') &&
     !pathname.includes('.') // naive static file check
   ) {
-    return NextResponse.redirect(new URL('/login', request.url));
+    const res = NextResponse.redirect(new URL('/login', request.url));
+    // Usually session won't exist here, but if it was just about to expire and we tried to refresh it,
+    // though getSession returning null means it's likely already gone or invalid.
+    return res;
   }
 
-  return NextResponse.next();
+  return sessionRes || NextResponse.next();
 }
 
 export const config = {


### PR DESCRIPTION
This PR fixes the bug where users were being logged out unexpectedly because the session refresh logic was failing to update the cookie in the browser.

Key changes:
1. **Middleware Propagation**: Previously, `middleware.ts` called `updateSession` but ignored the returned `NextResponse`. In Next.js, modifications to cookies in middleware only persist if the resulting response is returned to the client. I updated the middleware to correctly return or merge the refreshed session response.
2. **Robust Expiry Detection**: Modified `updateSession` in `lib/auth.ts` to use the standard JWT `exp` claim if the internal `expires` field is missing from the payload.
3. **Cookie Persistence in Redirects**: Added logic to ensure that if a session refresh occurs simultaneously with a redirect (e.g., hitting /login while authenticated), the new session cookie is still attached to the redirect response.

Verified the fix with a verification script that mocks various session states and confirms the 'Set-Cookie' header is present when expected.

---
*PR created automatically by Jules for task [14539883456346569745](https://jules.google.com/task/14539883456346569745) started by @testuser0123-web*