### PR TITLE
Fix video modal layout so comments remain visible

### DIFF
--- a/components/Feed.tsx
+++ b/components/Feed.tsx
@@ -523,10 +523,10 @@ export default function Feed({ initialPosts, currentUserId, feedType, searchQuer
              </button>
 
             {selectedPost.mediaType === "VIDEO" ? (
-                <div className="aspect-square bg-black flex items-center justify-center">
+                <div className="w-full h-[min(100vw,24rem)] max-h-[min(60vh,24rem)] shrink-0 bg-black flex items-center justify-center overflow-hidden">
                     <video
                         src={selectedPost.imageUrl || `/api/image/${selectedPost.id}.jpg`}
-                        className="w-full h-full object-contain"
+                        className="max-w-full max-h-full object-contain"
                         controls
                         autoPlay
                         loop
@@ -543,7 +543,7 @@ export default function Feed({ initialPosts, currentUserId, feedType, searchQuer
                 />
             )}
 
-            <div className="p-4 overflow-y-auto flex-1 dark:text-gray-100">
+            <div className="p-4 overflow-y-auto flex-1 min-h-0 dark:text-gray-100">
               <div className="flex items-center justify-between mb-2">
                 <div className="flex items-center gap-3">
                     <button
@@ -698,7 +698,7 @@ export default function Feed({ initialPosts, currentUserId, feedType, searchQuer
 
             {/* Add Comment Form */}
             {!isGuest && (
-              <div className="p-4 border-t dark:border-gray-800 flex flex-col">
+              <div className="p-4 border-t dark:border-gray-800 shrink-0 flex flex-col">
                 {replyingTo && (
                     <div className="flex justify-between items-center text-xs text-indigo-500 mb-2">
                         <span>@{replyingTo.username} に返信中...</span>

--- a/tests/video-modal-layout.test.mjs
+++ b/tests/video-modal-layout.test.mjs
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs';
+import assert from 'node:assert/strict';
+
+const source = readFileSync(new URL('../components/Feed.tsx', import.meta.url), 'utf8');
+
+assert.match(
+  source,
+  /className="[^"]*max-h-\[min\(60vh,24rem\)\][^"]*"/,
+  'video modal media container should cap vertical video height so comments are not squeezed'
+);
+
+assert.match(
+  source,
+  /className="[^"]*overflow-y-auto[^"]*min-h-0[^"]*"/,
+  'modal scrollable content should allow shrinking inside max-height flex column'
+);
+
+assert.match(
+  source,
+  /className="[^"]*border-t[^"]*shrink-0[^"]*"/,
+  'comment form container should not shrink when media/content compete for height'
+);


### PR DESCRIPTION
## Summary
- Cap the selected-post video media area height in the feed modal so tall 9:16 videos cannot consume the whole modal.
- Keep the scrollable details/comments section shrinkable with `min-h-0`.
- Prevent the comment form from shrinking when media and comments compete for vertical space.
- Add a lightweight regression check for the layout classes that protect the modal.

Closes #175

## Verification
- `node tests/video-modal-layout.test.mjs`
- `npx eslint components/Feed.tsx tests/video-modal-layout.test.mjs` — passes with one pre-existing `react-hooks/exhaustive-deps` warning in `components/Feed.tsx`.
- `npm run build` with local dummy env vars for required build-time secrets — passes.
- `npm run lint` still fails on pre-existing repository-wide lint errors outside this change.
