### PR TITLE
feat: add reaction preview popup

### DIFF
--- a/components/Feed.tsx
+++ b/components/Feed.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, type MouseEvent, type PointerEvent } from 'react';
 import { Heart, Plus, X, Trash2, BadgeCheck, Loader2, Share2, Send, User as UserIcon, Layers, AlertTriangle, Play, CornerDownRight } from 'lucide-react';
 import Link from 'next/link';
 import { useSearchParams, usePathname } from 'next/navigation';
@@ -124,6 +124,9 @@ export default function Feed({ initialPosts, currentUserId, feedType, searchQuer
   const [customEmojiError, setCustomEmojiError] = useState<string | null>(null);
   const [enlargedCustomEmoji, setEnlargedCustomEmoji] = useState<CustomEmojiSummary | null>(null);
   const commentInputRef = useRef<HTMLInputElement>(null);
+  const customEmojiPreviewTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const customEmojiPreviewDismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const suppressCustomEmojiClickRef = useRef(false);
 
   const getCommentTextDetails = (text: string) => {
     const replyPrefixRegex = /^@[^\s]+\s/;
@@ -345,6 +348,84 @@ export default function Feed({ initialPosts, currentUserId, feedType, searchQuer
     await toggleReaction(post.id, reactionKey);
   };
 
+  const clearCustomEmojiPreviewTimers = () => {
+    if (customEmojiPreviewTimerRef.current) {
+      clearTimeout(customEmojiPreviewTimerRef.current);
+      customEmojiPreviewTimerRef.current = null;
+    }
+    if (customEmojiPreviewDismissTimerRef.current) {
+      clearTimeout(customEmojiPreviewDismissTimerRef.current);
+      customEmojiPreviewDismissTimerRef.current = null;
+    }
+  };
+
+  const canHoverPreview = () =>
+    typeof window !== 'undefined' && window.matchMedia('(hover: hover) and (pointer: fine)').matches;
+
+  const showCustomEmojiPreview = (customEmoji: CustomEmojiSummary) => {
+    clearCustomEmojiPreviewTimers();
+    setEnlargedCustomEmoji(customEmoji);
+  };
+
+  const scheduleCustomEmojiPreviewHide = (delay = 0) => {
+    if (customEmojiPreviewDismissTimerRef.current) {
+      clearTimeout(customEmojiPreviewDismissTimerRef.current);
+    }
+    customEmojiPreviewDismissTimerRef.current = setTimeout(() => {
+      setEnlargedCustomEmoji(null);
+      customEmojiPreviewDismissTimerRef.current = null;
+    }, delay);
+  };
+
+  const handleCustomEmojiMouseEnter = (customEmoji: CustomEmojiSummary) => {
+    if (canHoverPreview()) showCustomEmojiPreview(customEmoji);
+  };
+
+  const handleCustomEmojiMouseLeave = () => {
+    if (canHoverPreview()) scheduleCustomEmojiPreviewHide(80);
+  };
+
+  const handleCustomEmojiPointerDown = (event: PointerEvent<HTMLButtonElement>, customEmoji: CustomEmojiSummary) => {
+    if (event.pointerType === 'mouse') return;
+    clearCustomEmojiPreviewTimers();
+    suppressCustomEmojiClickRef.current = false;
+    customEmojiPreviewTimerRef.current = setTimeout(() => {
+      suppressCustomEmojiClickRef.current = true;
+      setEnlargedCustomEmoji(customEmoji);
+    }, 450);
+  };
+
+  const handleCustomEmojiPointerUp = (event: PointerEvent<HTMLButtonElement>) => {
+    if (event.pointerType === 'mouse') return;
+    if (customEmojiPreviewTimerRef.current) {
+      clearTimeout(customEmojiPreviewTimerRef.current);
+      customEmojiPreviewTimerRef.current = null;
+    }
+    if (suppressCustomEmojiClickRef.current) scheduleCustomEmojiPreviewHide(900);
+  };
+
+  const handleCustomEmojiPointerCancel = () => {
+    clearCustomEmojiPreviewTimers();
+    setEnlargedCustomEmoji(null);
+    suppressCustomEmojiClickRef.current = false;
+  };
+
+  const handleCustomEmojiClick = (event: MouseEvent<HTMLButtonElement>, callback: () => void) => {
+    if (suppressCustomEmojiClickRef.current) {
+      event.preventDefault();
+      event.stopPropagation();
+      suppressCustomEmojiClickRef.current = false;
+      return;
+    }
+    callback();
+  };
+
+  useEffect(() => {
+    return () => {
+      if (customEmojiPreviewTimerRef.current) clearTimeout(customEmojiPreviewTimerRef.current);
+      if (customEmojiPreviewDismissTimerRef.current) clearTimeout(customEmojiPreviewDismissTimerRef.current);
+    };
+  }, []);
 
   const handleLike = async (post: Post) => {
     if (isGuest) {
@@ -752,31 +833,30 @@ export default function Feed({ initialPosts, currentUserId, feedType, searchQuer
               <div className="space-y-3 border-t dark:border-gray-800 pt-3">
                 <div className="flex flex-wrap items-center gap-1 pb-3 border-b border-gray-100 dark:border-gray-800" data-emoji-picker="unicode-emoji-grid">
                 {(selectedPost.reactions || []).map((reaction) => (
-                  <div key={reaction.reactionKey} className="inline-flex items-center overflow-hidden rounded-full border border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-900">
-                    <button
-                      type="button"
-                      onClick={() => handleReaction(selectedPost, reaction.reactionKey)}
-                      className={`px-2 py-1 text-sm transition-colors ${reaction.hasReacted ? 'bg-indigo-50 text-indigo-700 dark:bg-indigo-950 dark:text-indigo-200' : 'text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800'}`}
-                      title="リアクションを切り替え"
-                    >
-                      {reaction.customEmoji ? (
-                        <img src={getCustomEmojiImageSrc(reaction.customEmoji)} alt={`:${reaction.customEmoji.name}:`} width={24} height={24} className="mr-1 inline-block h-6 w-6 rounded-sm object-contain align-middle" />
-                      ) : (
-                        <span className="mr-1">{reaction.emoji}</span>
-                      )}
-                      <span className="text-xs font-semibold">{reaction.count}</span>
-                    </button>
-                    {reaction.customEmoji && (
-                      <button
-                        type="button"
-                        onClick={() => setEnlargedCustomEmoji(reaction.customEmoji ?? null)}
-                        className="border-l border-gray-200 px-2 py-1 text-[11px] font-semibold text-indigo-600 hover:bg-indigo-50 dark:border-gray-700 dark:text-indigo-300 dark:hover:bg-indigo-950"
-                        title={`:${reaction.customEmoji.name}: の画像を拡大表示`}
-                      >
-                        拡大
-                      </button>
+                  <button
+                    key={reaction.reactionKey}
+                    type="button"
+                    onClick={(event) => handleCustomEmojiClick(event, () => handleReaction(selectedPost, reaction.reactionKey))}
+                    onMouseEnter={() => reaction.customEmoji && handleCustomEmojiMouseEnter(reaction.customEmoji)}
+                    onMouseLeave={reaction.customEmoji ? handleCustomEmojiMouseLeave : undefined}
+                    onPointerDown={(event) => {
+                      if (reaction.customEmoji) handleCustomEmojiPointerDown(event, reaction.customEmoji);
+                    }}
+                    onPointerUp={reaction.customEmoji ? handleCustomEmojiPointerUp : undefined}
+                    onPointerCancel={reaction.customEmoji ? handleCustomEmojiPointerCancel : undefined}
+                    onPointerLeave={(event) => {
+                      if (event.pointerType !== 'mouse' && reaction.customEmoji) handleCustomEmojiPointerCancel();
+                    }}
+                    className={`px-2 py-1 rounded-full border text-sm transition-colors ${reaction.hasReacted ? 'bg-indigo-50 border-indigo-300 text-indigo-700 dark:bg-indigo-950 dark:border-indigo-700 dark:text-indigo-200' : 'bg-gray-50 border-gray-200 dark:bg-gray-900 dark:border-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800'}`}
+                    title="リアクションを切り替え。カスタム絵文字はPCではホバー、スマホでは長押しで拡大表示"
+                  >
+                    {reaction.customEmoji ? (
+                      <img src={getCustomEmojiImageSrc(reaction.customEmoji)} alt={`:${reaction.customEmoji.name}:`} width={24} height={24} className="mr-1 inline-block h-6 w-6 rounded-sm object-contain align-middle" />
+                    ) : (
+                      <span className="mr-1">{reaction.emoji}</span>
                     )}
-                  </div>
+                    <span className="text-xs font-semibold">{reaction.count}</span>
+                  </button>
                 ))}
                 <button
                   type="button"
@@ -885,16 +965,8 @@ export default function Feed({ initialPosts, currentUserId, feedType, searchQuer
       )}
 
       {enlargedCustomEmoji && (
-        <div className="fixed inset-0 z-[120] flex items-center justify-center bg-black/70 p-4" role="dialog" aria-modal="true" aria-label="カスタム絵文字画像を拡大表示">
-          <div className="relative flex max-w-[90vw] flex-col items-center gap-3 rounded-3xl border border-gray-200 bg-white p-6 shadow-2xl dark:border-gray-700 dark:bg-gray-900">
-            <button
-              type="button"
-              onClick={() => setEnlargedCustomEmoji(null)}
-              className="absolute right-3 top-3 rounded-full p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
-              aria-label="拡大画像を閉じる"
-            >
-              <X className="h-5 w-5" />
-            </button>
+        <div className="pointer-events-none fixed inset-0 z-[120] flex items-center justify-center p-4" aria-hidden="true">
+          <div className="flex max-w-[90vw] flex-col items-center gap-3 rounded-3xl border border-white/70 bg-white/95 p-6 text-gray-900 shadow-2xl backdrop-blur dark:border-gray-700/70 dark:bg-gray-900/95 dark:text-gray-100">
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
               src={getCustomEmojiImageSrc(enlargedCustomEmoji)}
@@ -931,24 +1003,23 @@ export default function Feed({ initialPosts, currentUserId, feedType, searchQuer
                 {customEmojis.length > 0 && (
                   <div className="mb-3 grid grid-cols-8 gap-1 sm:grid-cols-10 md:grid-cols-12">
                     {customEmojis.map((customEmoji) => (
-                      <div key={customEmoji.id} className="flex flex-col items-center gap-1 rounded-lg p-1 hover:bg-gray-100 dark:hover:bg-gray-800">
-                        <button
-                          type="button"
-                          onClick={() => handleReaction(reactionPickerPost, `custom:${customEmoji.id}`, customEmoji)}
-                          className="rounded-md p-1"
-                          title={`:${customEmoji.name}: を追加`}
-                        >
-                          <img src={getCustomEmojiImageSrc(customEmoji)} alt={`:${customEmoji.name}:`} width={32} height={32} className="h-8 w-8 object-contain" />
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => setEnlargedCustomEmoji(customEmoji)}
-                          className="rounded-full border border-indigo-200 px-2 py-0.5 text-[10px] font-semibold text-indigo-600 hover:bg-indigo-50 dark:border-indigo-700 dark:text-indigo-300 dark:hover:bg-indigo-950"
-                          title={`:${customEmoji.name}: の画像を拡大表示`}
-                        >
-                          拡大
-                        </button>
-                      </div>
+                      <button
+                        key={customEmoji.id}
+                        type="button"
+                        onClick={(event) => handleCustomEmojiClick(event, () => handleReaction(reactionPickerPost, `custom:${customEmoji.id}`, customEmoji))}
+                        onMouseEnter={() => handleCustomEmojiMouseEnter(customEmoji)}
+                        onMouseLeave={handleCustomEmojiMouseLeave}
+                        onPointerDown={(event) => handleCustomEmojiPointerDown(event, customEmoji)}
+                        onPointerUp={handleCustomEmojiPointerUp}
+                        onPointerCancel={handleCustomEmojiPointerCancel}
+                        onPointerLeave={(event) => {
+                          if (event.pointerType !== 'mouse') handleCustomEmojiPointerCancel();
+                        }}
+                        className="rounded-lg p-2 hover:bg-gray-100 dark:hover:bg-gray-800"
+                        title={`:${customEmoji.name}: を追加。PCではホバー、スマホでは長押しで拡大表示`}
+                      >
+                        <img src={getCustomEmojiImageSrc(customEmoji)} alt={`:${customEmoji.name}:`} width={32} height={32} className="h-8 w-8 object-contain" />
+                      </button>
                     ))}
                   </div>
                 )}

--- a/components/Feed.tsx
+++ b/components/Feed.tsx
@@ -122,6 +122,7 @@ export default function Feed({ initialPosts, currentUserId, feedType, searchQuer
   const [showReactionPickerForPostId, setShowReactionPickerForPostId] = useState<number | null>(null);
   const [customEmojis, setCustomEmojis] = useState<CustomEmojiSummary[]>([]);
   const [customEmojiError, setCustomEmojiError] = useState<string | null>(null);
+  const [enlargedCustomEmoji, setEnlargedCustomEmoji] = useState<CustomEmojiSummary | null>(null);
   const commentInputRef = useRef<HTMLInputElement>(null);
 
   const getCommentTextDetails = (text: string) => {
@@ -751,20 +752,31 @@ export default function Feed({ initialPosts, currentUserId, feedType, searchQuer
               <div className="space-y-3 border-t dark:border-gray-800 pt-3">
                 <div className="flex flex-wrap items-center gap-1 pb-3 border-b border-gray-100 dark:border-gray-800" data-emoji-picker="unicode-emoji-grid">
                 {(selectedPost.reactions || []).map((reaction) => (
-                  <button
-                    key={reaction.reactionKey}
-                    type="button"
-                    onClick={() => handleReaction(selectedPost, reaction.reactionKey)}
-                    className={`px-2 py-1 rounded-full border text-sm transition-colors ${reaction.hasReacted ? 'bg-indigo-50 border-indigo-300 text-indigo-700 dark:bg-indigo-950 dark:border-indigo-700 dark:text-indigo-200' : 'bg-gray-50 border-gray-200 dark:bg-gray-900 dark:border-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800'}`}
-                    title="リアクションを切り替え"
-                  >
-                    {reaction.customEmoji ? (
-                      <img src={getCustomEmojiImageSrc(reaction.customEmoji)} alt={`:${reaction.customEmoji.name}:`} width={24} height={24} className="mr-1 inline-block h-6 w-6 rounded-sm object-contain align-middle" />
-                    ) : (
-                      <span className="mr-1">{reaction.emoji}</span>
+                  <div key={reaction.reactionKey} className="inline-flex items-center overflow-hidden rounded-full border border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-900">
+                    <button
+                      type="button"
+                      onClick={() => handleReaction(selectedPost, reaction.reactionKey)}
+                      className={`px-2 py-1 text-sm transition-colors ${reaction.hasReacted ? 'bg-indigo-50 text-indigo-700 dark:bg-indigo-950 dark:text-indigo-200' : 'text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800'}`}
+                      title="リアクションを切り替え"
+                    >
+                      {reaction.customEmoji ? (
+                        <img src={getCustomEmojiImageSrc(reaction.customEmoji)} alt={`:${reaction.customEmoji.name}:`} width={24} height={24} className="mr-1 inline-block h-6 w-6 rounded-sm object-contain align-middle" />
+                      ) : (
+                        <span className="mr-1">{reaction.emoji}</span>
+                      )}
+                      <span className="text-xs font-semibold">{reaction.count}</span>
+                    </button>
+                    {reaction.customEmoji && (
+                      <button
+                        type="button"
+                        onClick={() => setEnlargedCustomEmoji(reaction.customEmoji ?? null)}
+                        className="border-l border-gray-200 px-2 py-1 text-[11px] font-semibold text-indigo-600 hover:bg-indigo-50 dark:border-gray-700 dark:text-indigo-300 dark:hover:bg-indigo-950"
+                        title={`:${reaction.customEmoji.name}: の画像を拡大表示`}
+                      >
+                        拡大
+                      </button>
                     )}
-                    <span className="text-xs font-semibold">{reaction.count}</span>
-                  </button>
+                  </div>
                 ))}
                 <button
                   type="button"
@@ -872,6 +884,30 @@ export default function Feed({ initialPosts, currentUserId, feedType, searchQuer
         </div>
       )}
 
+      {enlargedCustomEmoji && (
+        <div className="fixed inset-0 z-[120] flex items-center justify-center bg-black/70 p-4" role="dialog" aria-modal="true" aria-label="カスタム絵文字画像を拡大表示">
+          <div className="relative flex max-w-[90vw] flex-col items-center gap-3 rounded-3xl border border-gray-200 bg-white p-6 shadow-2xl dark:border-gray-700 dark:bg-gray-900">
+            <button
+              type="button"
+              onClick={() => setEnlargedCustomEmoji(null)}
+              className="absolute right-3 top-3 rounded-full p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+              aria-label="拡大画像を閉じる"
+            >
+              <X className="h-5 w-5" />
+            </button>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={getCustomEmojiImageSrc(enlargedCustomEmoji)}
+              alt={`:${enlargedCustomEmoji.name}:`}
+              width={192}
+              height={192}
+              className="h-48 w-48 rounded-xl object-contain"
+            />
+            <span className="text-sm font-semibold text-gray-700 dark:text-gray-200">:{enlargedCustomEmoji.name}:</span>
+          </div>
+        </div>
+      )}
+
       {reactionPickerPost && !isGuest && (
         <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 p-4" role="dialog" aria-modal="true" aria-label="絵文字リアクションを選択">
           <div data-emoji-picker-panel className="flex max-h-[80vh] w-full max-w-xl flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-2xl dark:border-gray-700 dark:bg-gray-900">
@@ -895,15 +931,24 @@ export default function Feed({ initialPosts, currentUserId, feedType, searchQuer
                 {customEmojis.length > 0 && (
                   <div className="mb-3 grid grid-cols-8 gap-1 sm:grid-cols-10 md:grid-cols-12">
                     {customEmojis.map((customEmoji) => (
-                      <button
-                        key={customEmoji.id}
-                        type="button"
-                        onClick={() => handleReaction(reactionPickerPost, `custom:${customEmoji.id}`, customEmoji)}
-                        className="rounded-lg p-2 hover:bg-gray-100 dark:hover:bg-gray-800"
-                        title={`:${customEmoji.name}: を追加`}
-                      >
-                        <img src={getCustomEmojiImageSrc(customEmoji)} alt={`:${customEmoji.name}:`} width={32} height={32} className="h-8 w-8 object-contain" />
-                      </button>
+                      <div key={customEmoji.id} className="flex flex-col items-center gap-1 rounded-lg p-1 hover:bg-gray-100 dark:hover:bg-gray-800">
+                        <button
+                          type="button"
+                          onClick={() => handleReaction(reactionPickerPost, `custom:${customEmoji.id}`, customEmoji)}
+                          className="rounded-md p-1"
+                          title={`:${customEmoji.name}: を追加`}
+                        >
+                          <img src={getCustomEmojiImageSrc(customEmoji)} alt={`:${customEmoji.name}:`} width={32} height={32} className="h-8 w-8 object-contain" />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => setEnlargedCustomEmoji(customEmoji)}
+                          className="rounded-full border border-indigo-200 px-2 py-0.5 text-[10px] font-semibold text-indigo-600 hover:bg-indigo-50 dark:border-indigo-700 dark:text-indigo-300 dark:hover:bg-indigo-950"
+                          title={`:${customEmoji.name}: の画像を拡大表示`}
+                        >
+                          拡大
+                        </button>
+                      </div>
                     ))}
                   </div>
                 )}

--- a/components/Feed.tsx
+++ b/components/Feed.tsx
@@ -387,6 +387,7 @@ export default function Feed({ initialPosts, currentUserId, feedType, searchQuer
 
   const handleCustomEmojiPointerDown = (event: PointerEvent<HTMLButtonElement>, customEmoji: CustomEmojiSummary) => {
     if (event.pointerType === 'mouse') return;
+    event.preventDefault();
     clearCustomEmojiPreviewTimers();
     suppressCustomEmojiClickRef.current = false;
     customEmojiPreviewTimerRef.current = setTimeout(() => {
@@ -847,11 +848,14 @@ export default function Feed({ initialPosts, currentUserId, feedType, searchQuer
                     onPointerLeave={(event) => {
                       if (event.pointerType !== 'mouse' && reaction.customEmoji) handleCustomEmojiPointerCancel();
                     }}
-                    className={`px-2 py-1 rounded-full border text-sm transition-colors ${reaction.hasReacted ? 'bg-indigo-50 border-indigo-300 text-indigo-700 dark:bg-indigo-950 dark:border-indigo-700 dark:text-indigo-200' : 'bg-gray-50 border-gray-200 dark:bg-gray-900 dark:border-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800'}`}
-                    title="リアクションを切り替え。カスタム絵文字はPCではホバー、スマホでは長押しで拡大表示"
+                    onContextMenu={(event) => {
+                      if (reaction.customEmoji) event.preventDefault();
+                    }}
+                    className={`select-none px-2 py-1 rounded-full border text-sm transition-colors [-webkit-touch-callout:none] ${reaction.hasReacted ? 'bg-indigo-50 border-indigo-300 text-indigo-700 dark:bg-indigo-950 dark:border-indigo-700 dark:text-indigo-200' : 'bg-gray-50 border-gray-200 dark:bg-gray-900 dark:border-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800'}`}
+                    aria-label={reaction.customEmoji ? `:${reaction.customEmoji.name}: のリアクションを切り替え` : `${reaction.emoji} のリアクションを切り替え`}
                   >
                     {reaction.customEmoji ? (
-                      <img src={getCustomEmojiImageSrc(reaction.customEmoji)} alt={`:${reaction.customEmoji.name}:`} width={24} height={24} className="mr-1 inline-block h-6 w-6 rounded-sm object-contain align-middle" />
+                      <img src={getCustomEmojiImageSrc(reaction.customEmoji)} alt={`:${reaction.customEmoji.name}:`} width={24} height={24} draggable={false} className="mr-1 inline-block h-6 w-6 select-none rounded-sm object-contain align-middle [-webkit-touch-callout:none]" />
                     ) : (
                       <span className="mr-1">{reaction.emoji}</span>
                     )}
@@ -966,16 +970,16 @@ export default function Feed({ initialPosts, currentUserId, feedType, searchQuer
 
       {enlargedCustomEmoji && (
         <div className="pointer-events-none fixed inset-0 z-[120] flex items-center justify-center p-4" aria-hidden="true">
-          <div className="flex max-w-[90vw] flex-col items-center gap-3 rounded-3xl border border-white/70 bg-white/95 p-6 text-gray-900 shadow-2xl backdrop-blur dark:border-gray-700/70 dark:bg-gray-900/95 dark:text-gray-100">
+          <div className="flex max-w-[90vw] items-center justify-center rounded-3xl border border-white/70 bg-white/95 p-6 shadow-2xl backdrop-blur dark:border-gray-700/70 dark:bg-gray-900/95">
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
               src={getCustomEmojiImageSrc(enlargedCustomEmoji)}
               alt={`:${enlargedCustomEmoji.name}:`}
               width={192}
               height={192}
-              className="h-48 w-48 rounded-xl object-contain"
+              draggable={false}
+              className="h-48 w-48 select-none rounded-xl object-contain [-webkit-touch-callout:none]"
             />
-            <span className="text-sm font-semibold text-gray-700 dark:text-gray-200">:{enlargedCustomEmoji.name}:</span>
           </div>
         </div>
       )}
@@ -1015,10 +1019,11 @@ export default function Feed({ initialPosts, currentUserId, feedType, searchQuer
                         onPointerLeave={(event) => {
                           if (event.pointerType !== 'mouse') handleCustomEmojiPointerCancel();
                         }}
-                        className="rounded-lg p-2 hover:bg-gray-100 dark:hover:bg-gray-800"
-                        title={`:${customEmoji.name}: を追加。PCではホバー、スマホでは長押しで拡大表示`}
+                        onContextMenu={(event) => event.preventDefault()}
+                        className="select-none rounded-lg p-2 [-webkit-touch-callout:none] hover:bg-gray-100 dark:hover:bg-gray-800"
+                        aria-label={`:${customEmoji.name}: を追加`}
                       >
-                        <img src={getCustomEmojiImageSrc(customEmoji)} alt={`:${customEmoji.name}:`} width={32} height={32} className="h-8 w-8 object-contain" />
+                        <img src={getCustomEmojiImageSrc(customEmoji)} alt={`:${customEmoji.name}:`} width={32} height={32} draggable={false} className="h-8 w-8 select-none object-contain [-webkit-touch-callout:none]" />
                       </button>
                     ))}
                   </div>

--- a/components/SinglePost.tsx
+++ b/components/SinglePost.tsx
@@ -99,7 +99,10 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
   const commentInputRef = useRef<HTMLInputElement>(null);
   const reactionPreviewTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reactionPreviewDismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const customEmojiPreviewTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const customEmojiPreviewDismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const suppressReactionClickRef = useRef(false);
+  const suppressCustomEmojiClickRef = useRef(false);
 
   const getCommentTextDetails = (text: string) => {
     const replyPrefixRegex = /^@[^\s]+\s/;
@@ -173,12 +176,28 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
     }
   };
 
+  const clearCustomEmojiPreviewTimers = () => {
+    if (customEmojiPreviewTimerRef.current) {
+      clearTimeout(customEmojiPreviewTimerRef.current);
+      customEmojiPreviewTimerRef.current = null;
+    }
+    if (customEmojiPreviewDismissTimerRef.current) {
+      clearTimeout(customEmojiPreviewDismissTimerRef.current);
+      customEmojiPreviewDismissTimerRef.current = null;
+    }
+  };
+
   const canHoverPreview = () =>
     typeof window !== 'undefined' && window.matchMedia('(hover: hover) and (pointer: fine)').matches;
 
   const showReactionPreview = (reaction: PostReactionSummary) => {
     clearReactionPreviewTimers();
     setPreviewReaction(reaction);
+  };
+
+  const showCustomEmojiPreview = (customEmoji: CustomEmojiSummary) => {
+    clearCustomEmojiPreviewTimers();
+    setEnlargedCustomEmoji(customEmoji);
   };
 
   const scheduleReactionPreviewHide = (delay = 0) => {
@@ -191,12 +210,30 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
     }, delay);
   };
 
+  const scheduleCustomEmojiPreviewHide = (delay = 0) => {
+    if (customEmojiPreviewDismissTimerRef.current) {
+      clearTimeout(customEmojiPreviewDismissTimerRef.current);
+    }
+    customEmojiPreviewDismissTimerRef.current = setTimeout(() => {
+      setEnlargedCustomEmoji(null);
+      customEmojiPreviewDismissTimerRef.current = null;
+    }, delay);
+  };
+
   const handleReactionMouseEnter = (reaction: PostReactionSummary) => {
     if (canHoverPreview()) showReactionPreview(reaction);
   };
 
   const handleReactionMouseLeave = () => {
     if (canHoverPreview()) scheduleReactionPreviewHide(80);
+  };
+
+  const handleCustomEmojiMouseEnter = (customEmoji: CustomEmojiSummary) => {
+    if (canHoverPreview()) showCustomEmojiPreview(customEmoji);
+  };
+
+  const handleCustomEmojiMouseLeave = () => {
+    if (canHoverPreview()) scheduleCustomEmojiPreviewHide(80);
   };
 
   const handleReactionPointerDown = (event: PointerEvent<HTMLButtonElement>, reaction: PostReactionSummary) => {
@@ -209,6 +246,16 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
     }, 450);
   };
 
+  const handleCustomEmojiPointerDown = (event: PointerEvent<HTMLButtonElement>, customEmoji: CustomEmojiSummary) => {
+    if (event.pointerType === 'mouse') return;
+    clearCustomEmojiPreviewTimers();
+    suppressCustomEmojiClickRef.current = false;
+    customEmojiPreviewTimerRef.current = setTimeout(() => {
+      suppressCustomEmojiClickRef.current = true;
+      setEnlargedCustomEmoji(customEmoji);
+    }, 450);
+  };
+
   const handleReactionPointerUp = (event: PointerEvent<HTMLButtonElement>) => {
     if (event.pointerType === 'mouse') return;
     if (reactionPreviewTimerRef.current) {
@@ -218,10 +265,25 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
     if (suppressReactionClickRef.current) scheduleReactionPreviewHide(900);
   };
 
+  const handleCustomEmojiPointerUp = (event: PointerEvent<HTMLButtonElement>) => {
+    if (event.pointerType === 'mouse') return;
+    if (customEmojiPreviewTimerRef.current) {
+      clearTimeout(customEmojiPreviewTimerRef.current);
+      customEmojiPreviewTimerRef.current = null;
+    }
+    if (suppressCustomEmojiClickRef.current) scheduleCustomEmojiPreviewHide(900);
+  };
+
   const handleReactionPointerCancel = () => {
     clearReactionPreviewTimers();
     setPreviewReaction(null);
     suppressReactionClickRef.current = false;
+  };
+
+  const handleCustomEmojiPointerCancel = () => {
+    clearCustomEmojiPreviewTimers();
+    setEnlargedCustomEmoji(null);
+    suppressCustomEmojiClickRef.current = false;
   };
 
   const handleReactionChipClick = (event: MouseEvent<HTMLButtonElement>, reactionKey: string) => {
@@ -234,10 +296,22 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
     handleReaction(reactionKey);
   };
 
+  const handleCustomEmojiPickerClick = (event: MouseEvent<HTMLButtonElement>, customEmoji: CustomEmojiSummary) => {
+    if (suppressCustomEmojiClickRef.current) {
+      event.preventDefault();
+      event.stopPropagation();
+      suppressCustomEmojiClickRef.current = false;
+      return;
+    }
+    handleReaction(`custom:${customEmoji.id}`, customEmoji);
+  };
+
   useEffect(() => {
     return () => {
       if (reactionPreviewTimerRef.current) clearTimeout(reactionPreviewTimerRef.current);
       if (reactionPreviewDismissTimerRef.current) clearTimeout(reactionPreviewDismissTimerRef.current);
+      if (customEmojiPreviewTimerRef.current) clearTimeout(customEmojiPreviewTimerRef.current);
+      if (customEmojiPreviewDismissTimerRef.current) clearTimeout(customEmojiPreviewDismissTimerRef.current);
     };
   }, []);
 
@@ -483,39 +557,28 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
          <div className="space-y-3 border-t dark:border-gray-800 pt-3">
            <div className="flex flex-wrap items-center gap-1 pb-3 border-b border-gray-100 dark:border-gray-800" data-emoji-picker="unicode-emoji-grid">
            {(post.reactions || []).map((reaction) => (
-             <div key={reaction.reactionKey} className="inline-flex items-center overflow-hidden rounded-full border border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-900">
-               <button
-                 type="button"
-                 onClick={(event) => handleReactionChipClick(event, reaction.reactionKey)}
-                 onMouseEnter={() => handleReactionMouseEnter(reaction)}
-                 onMouseLeave={handleReactionMouseLeave}
-                 onPointerDown={(event) => handleReactionPointerDown(event, reaction)}
-                 onPointerUp={handleReactionPointerUp}
-                 onPointerCancel={handleReactionPointerCancel}
-                 onPointerLeave={(event) => {
-                   if (event.pointerType !== 'mouse') handleReactionPointerCancel();
-                 }}
-                 className={`px-2 py-1 text-sm transition-colors ${reaction.hasReacted ? 'bg-indigo-50 text-indigo-700 dark:bg-indigo-950 dark:text-indigo-200' : 'text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800'}`}
-                 title="リアクションを切り替え"
-               >
-                 {reaction.customEmoji ? (
-                   <img src={getCustomEmojiImageSrc(reaction.customEmoji)} alt={`:${reaction.customEmoji.name}:`} width={24} height={24} className="mr-1 inline-block h-6 w-6 rounded-sm object-contain align-middle" />
-                 ) : (
-                   <span className="mr-1">{reaction.emoji}</span>
-                 )}
-                 <span className="text-xs font-semibold">{reaction.count}</span>
-               </button>
-               {reaction.customEmoji && (
-                 <button
-                   type="button"
-                   onClick={() => setEnlargedCustomEmoji(reaction.customEmoji ?? null)}
-                   className="border-l border-gray-200 px-2 py-1 text-[11px] font-semibold text-indigo-600 hover:bg-indigo-50 dark:border-gray-700 dark:text-indigo-300 dark:hover:bg-indigo-950"
-                   title={`:${reaction.customEmoji.name}: の画像を拡大表示`}
-                 >
-                   拡大
-                 </button>
+             <button
+               key={reaction.reactionKey}
+               type="button"
+               onClick={(event) => handleReactionChipClick(event, reaction.reactionKey)}
+               onMouseEnter={() => handleReactionMouseEnter(reaction)}
+               onMouseLeave={handleReactionMouseLeave}
+               onPointerDown={(event) => handleReactionPointerDown(event, reaction)}
+               onPointerUp={handleReactionPointerUp}
+               onPointerCancel={handleReactionPointerCancel}
+               onPointerLeave={(event) => {
+                 if (event.pointerType !== 'mouse') handleReactionPointerCancel();
+               }}
+               className={`px-2 py-1 rounded-full border text-sm transition-colors ${reaction.hasReacted ? 'bg-indigo-50 border-indigo-300 text-indigo-700 dark:bg-indigo-950 dark:border-indigo-700 dark:text-indigo-200' : 'bg-gray-50 border-gray-200 dark:bg-gray-900 dark:border-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800'}`}
+               title="PCではホバー、スマホでは長押しで拡大表示。クリックでリアクションを切り替え"
+             >
+               {reaction.customEmoji ? (
+                 <img src={getCustomEmojiImageSrc(reaction.customEmoji)} alt={`:${reaction.customEmoji.name}:`} width={24} height={24} className="mr-1 inline-block h-6 w-6 rounded-sm object-contain align-middle" />
+               ) : (
+                 <span className="mr-1">{reaction.emoji}</span>
                )}
-             </div>
+               <span className="text-xs font-semibold">{reaction.count}</span>
+             </button>
            ))}
            <button
              type="button"
@@ -620,9 +683,9 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
             <img
               src={getCustomEmojiImageSrc(previewReaction.customEmoji)}
               alt={`:${previewReaction.customEmoji.name}:`}
-              width={96}
-              height={96}
-              className="h-24 w-24 rounded-lg object-contain"
+              width={192}
+              height={192}
+              className="h-48 w-48 rounded-xl object-contain"
             />
           ) : (
             <span className="text-7xl leading-none">{previewReaction.emoji}</span>
@@ -633,16 +696,8 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
     )}
 
     {enlargedCustomEmoji && (
-      <div className="fixed inset-0 z-[120] flex items-center justify-center bg-black/70 p-4" role="dialog" aria-modal="true" aria-label="カスタム絵文字画像を拡大表示">
-        <div className="relative flex max-w-[90vw] flex-col items-center gap-3 rounded-3xl border border-gray-200 bg-white p-6 shadow-2xl dark:border-gray-700 dark:bg-gray-900">
-          <button
-            type="button"
-            onClick={() => setEnlargedCustomEmoji(null)}
-            className="absolute right-3 top-3 rounded-full p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
-            aria-label="拡大画像を閉じる"
-          >
-            <X className="h-5 w-5" />
-          </button>
+      <div className="pointer-events-none fixed inset-0 z-[120] flex items-center justify-center p-4" aria-hidden="true">
+        <div className="flex max-w-[90vw] flex-col items-center gap-3 rounded-3xl border border-white/70 bg-white/95 p-6 text-gray-900 shadow-2xl backdrop-blur dark:border-gray-700/70 dark:bg-gray-900/95 dark:text-gray-100">
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={getCustomEmojiImageSrc(enlargedCustomEmoji)}
@@ -679,24 +734,23 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
               {customEmojis.length > 0 && (
                 <div className="mb-3 grid grid-cols-8 gap-1 sm:grid-cols-10 md:grid-cols-12">
                   {customEmojis.map((customEmoji) => (
-                    <div key={customEmoji.id} className="flex flex-col items-center gap-1 rounded-lg p-1 hover:bg-gray-100 dark:hover:bg-gray-800">
-                      <button
-                        type="button"
-                        onClick={() => handleReaction(`custom:${customEmoji.id}`, customEmoji)}
-                        className="rounded-md p-1"
-                        title={`:${customEmoji.name}: を追加`}
-                      >
-                        <img src={getCustomEmojiImageSrc(customEmoji)} alt={`:${customEmoji.name}:`} width={32} height={32} className="h-8 w-8 object-contain" />
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => setEnlargedCustomEmoji(customEmoji)}
-                        className="rounded-full border border-indigo-200 px-2 py-0.5 text-[10px] font-semibold text-indigo-600 hover:bg-indigo-50 dark:border-indigo-700 dark:text-indigo-300 dark:hover:bg-indigo-950"
-                        title={`:${customEmoji.name}: の画像を拡大表示`}
-                      >
-                        拡大
-                      </button>
-                    </div>
+                    <button
+                      key={customEmoji.id}
+                      type="button"
+                      onClick={(event) => handleCustomEmojiPickerClick(event, customEmoji)}
+                      onMouseEnter={() => handleCustomEmojiMouseEnter(customEmoji)}
+                      onMouseLeave={handleCustomEmojiMouseLeave}
+                      onPointerDown={(event) => handleCustomEmojiPointerDown(event, customEmoji)}
+                      onPointerUp={handleCustomEmojiPointerUp}
+                      onPointerCancel={handleCustomEmojiPointerCancel}
+                      onPointerLeave={(event) => {
+                        if (event.pointerType !== 'mouse') handleCustomEmojiPointerCancel();
+                      }}
+                      className="rounded-lg p-2 hover:bg-gray-100 dark:hover:bg-gray-800"
+                      title={`:${customEmoji.name}: を追加。PCではホバー、スマホでは長押しで拡大表示`}
+                    >
+                      <img src={getCustomEmojiImageSrc(customEmoji)} alt={`:${customEmoji.name}:`} width={32} height={32} className="h-8 w-8 object-contain" />
+                    </button>
                   ))}
                 </div>
               )}

--- a/components/SinglePost.tsx
+++ b/components/SinglePost.tsx
@@ -238,6 +238,7 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
 
   const handleReactionPointerDown = (event: PointerEvent<HTMLButtonElement>, reaction: PostReactionSummary) => {
     if (event.pointerType === 'mouse') return;
+    event.preventDefault();
     clearReactionPreviewTimers();
     suppressReactionClickRef.current = false;
     reactionPreviewTimerRef.current = setTimeout(() => {
@@ -248,6 +249,7 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
 
   const handleCustomEmojiPointerDown = (event: PointerEvent<HTMLButtonElement>, customEmoji: CustomEmojiSummary) => {
     if (event.pointerType === 'mouse') return;
+    event.preventDefault();
     clearCustomEmojiPreviewTimers();
     suppressCustomEmojiClickRef.current = false;
     customEmojiPreviewTimerRef.current = setTimeout(() => {
@@ -561,19 +563,24 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
                key={reaction.reactionKey}
                type="button"
                onClick={(event) => handleReactionChipClick(event, reaction.reactionKey)}
-               onMouseEnter={() => handleReactionMouseEnter(reaction)}
-               onMouseLeave={handleReactionMouseLeave}
-               onPointerDown={(event) => handleReactionPointerDown(event, reaction)}
-               onPointerUp={handleReactionPointerUp}
-               onPointerCancel={handleReactionPointerCancel}
-               onPointerLeave={(event) => {
-                 if (event.pointerType !== 'mouse') handleReactionPointerCancel();
+               onMouseEnter={() => reaction.customEmoji && handleReactionMouseEnter(reaction)}
+               onMouseLeave={reaction.customEmoji ? handleReactionMouseLeave : undefined}
+               onPointerDown={(event) => {
+                 if (reaction.customEmoji) handleReactionPointerDown(event, reaction);
                }}
-               className={`px-2 py-1 rounded-full border text-sm transition-colors ${reaction.hasReacted ? 'bg-indigo-50 border-indigo-300 text-indigo-700 dark:bg-indigo-950 dark:border-indigo-700 dark:text-indigo-200' : 'bg-gray-50 border-gray-200 dark:bg-gray-900 dark:border-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800'}`}
-               title="PCではホバー、スマホでは長押しで拡大表示。クリックでリアクションを切り替え"
+               onPointerUp={reaction.customEmoji ? handleReactionPointerUp : undefined}
+               onPointerCancel={reaction.customEmoji ? handleReactionPointerCancel : undefined}
+               onPointerLeave={(event) => {
+                 if (event.pointerType !== 'mouse' && reaction.customEmoji) handleReactionPointerCancel();
+               }}
+               onContextMenu={(event) => {
+                 if (reaction.customEmoji) event.preventDefault();
+               }}
+               className={`select-none px-2 py-1 rounded-full border text-sm transition-colors [-webkit-touch-callout:none] ${reaction.hasReacted ? 'bg-indigo-50 border-indigo-300 text-indigo-700 dark:bg-indigo-950 dark:border-indigo-700 dark:text-indigo-200' : 'bg-gray-50 border-gray-200 dark:bg-gray-900 dark:border-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800'}`}
+               aria-label={reaction.customEmoji ? `:${reaction.customEmoji.name}: のリアクションを切り替え` : `${reaction.emoji} のリアクションを切り替え`}
              >
                {reaction.customEmoji ? (
-                 <img src={getCustomEmojiImageSrc(reaction.customEmoji)} alt={`:${reaction.customEmoji.name}:`} width={24} height={24} className="mr-1 inline-block h-6 w-6 rounded-sm object-contain align-middle" />
+                 <img src={getCustomEmojiImageSrc(reaction.customEmoji)} alt={`:${reaction.customEmoji.name}:`} width={24} height={24} draggable={false} className="mr-1 inline-block h-6 w-6 select-none rounded-sm object-contain align-middle [-webkit-touch-callout:none]" />
                ) : (
                  <span className="mr-1">{reaction.emoji}</span>
                )}
@@ -675,38 +682,34 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
        </div>
     </div>
 
-    {previewReaction && (
+    {previewReaction?.customEmoji && (
       <div className="pointer-events-none fixed inset-0 z-[90] flex items-center justify-center p-4" aria-hidden="true">
-        <div className="flex min-w-28 flex-col items-center gap-2 rounded-3xl border border-white/70 bg-white/95 px-6 py-5 text-gray-900 shadow-2xl backdrop-blur dark:border-gray-700/70 dark:bg-gray-900/95 dark:text-gray-100">
-          {previewReaction.customEmoji ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
-              src={getCustomEmojiImageSrc(previewReaction.customEmoji)}
-              alt={`:${previewReaction.customEmoji.name}:`}
-              width={192}
-              height={192}
-              className="h-48 w-48 rounded-xl object-contain"
-            />
-          ) : (
-            <span className="text-7xl leading-none">{previewReaction.emoji}</span>
-          )}
-          <span className="text-sm font-semibold text-gray-600 dark:text-gray-300">{previewReaction.count}</span>
+        <div className="flex max-w-[90vw] items-center justify-center rounded-3xl border border-white/70 bg-white/95 p-6 shadow-2xl backdrop-blur dark:border-gray-700/70 dark:bg-gray-900/95">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={getCustomEmojiImageSrc(previewReaction.customEmoji)}
+            alt={`:${previewReaction.customEmoji.name}:`}
+            width={192}
+            height={192}
+            draggable={false}
+            className="h-48 w-48 select-none rounded-xl object-contain [-webkit-touch-callout:none]"
+          />
         </div>
       </div>
     )}
 
     {enlargedCustomEmoji && (
       <div className="pointer-events-none fixed inset-0 z-[120] flex items-center justify-center p-4" aria-hidden="true">
-        <div className="flex max-w-[90vw] flex-col items-center gap-3 rounded-3xl border border-white/70 bg-white/95 p-6 text-gray-900 shadow-2xl backdrop-blur dark:border-gray-700/70 dark:bg-gray-900/95 dark:text-gray-100">
+        <div className="flex max-w-[90vw] items-center justify-center rounded-3xl border border-white/70 bg-white/95 p-6 shadow-2xl backdrop-blur dark:border-gray-700/70 dark:bg-gray-900/95">
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={getCustomEmojiImageSrc(enlargedCustomEmoji)}
             alt={`:${enlargedCustomEmoji.name}:`}
             width={192}
             height={192}
-            className="h-48 w-48 rounded-xl object-contain"
+            draggable={false}
+            className="h-48 w-48 select-none rounded-xl object-contain [-webkit-touch-callout:none]"
           />
-          <span className="text-sm font-semibold text-gray-700 dark:text-gray-200">:{enlargedCustomEmoji.name}:</span>
         </div>
       </div>
     )}
@@ -746,10 +749,11 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
                       onPointerLeave={(event) => {
                         if (event.pointerType !== 'mouse') handleCustomEmojiPointerCancel();
                       }}
-                      className="rounded-lg p-2 hover:bg-gray-100 dark:hover:bg-gray-800"
-                      title={`:${customEmoji.name}: を追加。PCではホバー、スマホでは長押しで拡大表示`}
+                      onContextMenu={(event) => event.preventDefault()}
+                      className="select-none rounded-lg p-2 [-webkit-touch-callout:none] hover:bg-gray-100 dark:hover:bg-gray-800"
+                      aria-label={`:${customEmoji.name}: を追加`}
                     >
-                      <img src={getCustomEmojiImageSrc(customEmoji)} alt={`:${customEmoji.name}:`} width={32} height={32} className="h-8 w-8 object-contain" />
+                      <img src={getCustomEmojiImageSrc(customEmoji)} alt={`:${customEmoji.name}:`} width={32} height={32} draggable={false} className="h-8 w-8 select-none object-contain [-webkit-touch-callout:none]" />
                     </button>
                   ))}
                 </div>

--- a/components/SinglePost.tsx
+++ b/components/SinglePost.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, type FormEvent, type MouseEvent, type PointerEvent } from 'react';
 import { Heart, Trash2, BadgeCheck, Loader2, Share2, Send, User as UserIcon, AlertTriangle, CornerDownRight, X, Plus } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -94,7 +94,11 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
   const [showReactionPicker, setShowReactionPicker] = useState(false);
   const [customEmojis, setCustomEmojis] = useState<CustomEmojiSummary[]>([]);
   const [customEmojiError, setCustomEmojiError] = useState<string | null>(null);
+  const [previewReaction, setPreviewReaction] = useState<PostReactionSummary | null>(null);
   const commentInputRef = useRef<HTMLInputElement>(null);
+  const reactionPreviewTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reactionPreviewDismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const suppressReactionClickRef = useRef(false);
 
   const getCommentTextDetails = (text: string) => {
     const replyPrefixRegex = /^@[^\s]+\s/;
@@ -157,6 +161,85 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
     await toggleReaction(post.id, reactionKey);
   };
 
+  const clearReactionPreviewTimers = () => {
+    if (reactionPreviewTimerRef.current) {
+      clearTimeout(reactionPreviewTimerRef.current);
+      reactionPreviewTimerRef.current = null;
+    }
+    if (reactionPreviewDismissTimerRef.current) {
+      clearTimeout(reactionPreviewDismissTimerRef.current);
+      reactionPreviewDismissTimerRef.current = null;
+    }
+  };
+
+  const canHoverPreview = () =>
+    typeof window !== 'undefined' && window.matchMedia('(hover: hover) and (pointer: fine)').matches;
+
+  const showReactionPreview = (reaction: PostReactionSummary) => {
+    clearReactionPreviewTimers();
+    setPreviewReaction(reaction);
+  };
+
+  const scheduleReactionPreviewHide = (delay = 0) => {
+    if (reactionPreviewDismissTimerRef.current) {
+      clearTimeout(reactionPreviewDismissTimerRef.current);
+    }
+    reactionPreviewDismissTimerRef.current = setTimeout(() => {
+      setPreviewReaction(null);
+      reactionPreviewDismissTimerRef.current = null;
+    }, delay);
+  };
+
+  const handleReactionMouseEnter = (reaction: PostReactionSummary) => {
+    if (canHoverPreview()) showReactionPreview(reaction);
+  };
+
+  const handleReactionMouseLeave = () => {
+    if (canHoverPreview()) scheduleReactionPreviewHide(80);
+  };
+
+  const handleReactionPointerDown = (event: PointerEvent<HTMLButtonElement>, reaction: PostReactionSummary) => {
+    if (event.pointerType === 'mouse') return;
+    clearReactionPreviewTimers();
+    suppressReactionClickRef.current = false;
+    reactionPreviewTimerRef.current = setTimeout(() => {
+      suppressReactionClickRef.current = true;
+      setPreviewReaction(reaction);
+    }, 450);
+  };
+
+  const handleReactionPointerUp = (event: PointerEvent<HTMLButtonElement>) => {
+    if (event.pointerType === 'mouse') return;
+    if (reactionPreviewTimerRef.current) {
+      clearTimeout(reactionPreviewTimerRef.current);
+      reactionPreviewTimerRef.current = null;
+    }
+    if (suppressReactionClickRef.current) scheduleReactionPreviewHide(900);
+  };
+
+  const handleReactionPointerCancel = () => {
+    clearReactionPreviewTimers();
+    setPreviewReaction(null);
+    suppressReactionClickRef.current = false;
+  };
+
+  const handleReactionChipClick = (event: MouseEvent<HTMLButtonElement>, reactionKey: string) => {
+    if (suppressReactionClickRef.current) {
+      event.preventDefault();
+      event.stopPropagation();
+      suppressReactionClickRef.current = false;
+      return;
+    }
+    handleReaction(reactionKey);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (reactionPreviewTimerRef.current) clearTimeout(reactionPreviewTimerRef.current);
+      if (reactionPreviewDismissTimerRef.current) clearTimeout(reactionPreviewDismissTimerRef.current);
+    };
+  }, []);
+
 
   const handleLike = async () => {
     // Optimistic update
@@ -190,7 +273,7 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
       }
   };
 
-  const handleAddComment = async (e: React.FormEvent) => {
+  const handleAddComment = async (e: FormEvent<HTMLFormElement>) => {
       e.preventDefault();
       if (!actualText.trim()) return;
 
@@ -402,9 +485,17 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
              <button
                key={reaction.reactionKey}
                type="button"
-               onClick={() => handleReaction(reaction.reactionKey)}
+               onClick={(event) => handleReactionChipClick(event, reaction.reactionKey)}
+               onMouseEnter={() => handleReactionMouseEnter(reaction)}
+               onMouseLeave={handleReactionMouseLeave}
+               onPointerDown={(event) => handleReactionPointerDown(event, reaction)}
+               onPointerUp={handleReactionPointerUp}
+               onPointerCancel={handleReactionPointerCancel}
+               onPointerLeave={(event) => {
+                 if (event.pointerType !== 'mouse') handleReactionPointerCancel();
+               }}
                className={`px-2 py-1 rounded-full border text-sm transition-colors ${reaction.hasReacted ? 'bg-indigo-50 border-indigo-300 text-indigo-700 dark:bg-indigo-950 dark:border-indigo-700 dark:text-indigo-200' : 'bg-gray-50 border-gray-200 dark:bg-gray-900 dark:border-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800'}`}
-               title="リアクションを切り替え"
+               title="PCではホバー、スマホでは長押しで拡大表示。クリックでリアクションを切り替え"
              >
                {reaction.customEmoji ? (
                  <img src={getCustomEmojiImageSrc(reaction.customEmoji)} alt={`:${reaction.customEmoji.name}:`} width={24} height={24} className="mr-1 inline-block h-6 w-6 rounded-sm object-contain align-middle" />
@@ -508,6 +599,26 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
            </div>
        </div>
     </div>
+
+    {previewReaction && (
+      <div className="pointer-events-none fixed inset-0 z-[90] flex items-center justify-center p-4" aria-hidden="true">
+        <div className="flex min-w-28 flex-col items-center gap-2 rounded-3xl border border-white/70 bg-white/95 px-6 py-5 text-gray-900 shadow-2xl backdrop-blur dark:border-gray-700/70 dark:bg-gray-900/95 dark:text-gray-100">
+          {previewReaction.customEmoji ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={getCustomEmojiImageSrc(previewReaction.customEmoji)}
+              alt={`:${previewReaction.customEmoji.name}:`}
+              width={96}
+              height={96}
+              className="h-24 w-24 rounded-lg object-contain"
+            />
+          ) : (
+            <span className="text-7xl leading-none">{previewReaction.emoji}</span>
+          )}
+          <span className="text-sm font-semibold text-gray-600 dark:text-gray-300">{previewReaction.count}</span>
+        </div>
+      </div>
+    )}
 
     {showReactionPicker && !isGuest && (
       <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 p-4" role="dialog" aria-modal="true" aria-label="絵文字リアクションを選択">

--- a/components/SinglePost.tsx
+++ b/components/SinglePost.tsx
@@ -95,6 +95,7 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
   const [customEmojis, setCustomEmojis] = useState<CustomEmojiSummary[]>([]);
   const [customEmojiError, setCustomEmojiError] = useState<string | null>(null);
   const [previewReaction, setPreviewReaction] = useState<PostReactionSummary | null>(null);
+  const [enlargedCustomEmoji, setEnlargedCustomEmoji] = useState<CustomEmojiSummary | null>(null);
   const commentInputRef = useRef<HTMLInputElement>(null);
   const reactionPreviewTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reactionPreviewDismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -482,28 +483,39 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
          <div className="space-y-3 border-t dark:border-gray-800 pt-3">
            <div className="flex flex-wrap items-center gap-1 pb-3 border-b border-gray-100 dark:border-gray-800" data-emoji-picker="unicode-emoji-grid">
            {(post.reactions || []).map((reaction) => (
-             <button
-               key={reaction.reactionKey}
-               type="button"
-               onClick={(event) => handleReactionChipClick(event, reaction.reactionKey)}
-               onMouseEnter={() => handleReactionMouseEnter(reaction)}
-               onMouseLeave={handleReactionMouseLeave}
-               onPointerDown={(event) => handleReactionPointerDown(event, reaction)}
-               onPointerUp={handleReactionPointerUp}
-               onPointerCancel={handleReactionPointerCancel}
-               onPointerLeave={(event) => {
-                 if (event.pointerType !== 'mouse') handleReactionPointerCancel();
-               }}
-               className={`px-2 py-1 rounded-full border text-sm transition-colors ${reaction.hasReacted ? 'bg-indigo-50 border-indigo-300 text-indigo-700 dark:bg-indigo-950 dark:border-indigo-700 dark:text-indigo-200' : 'bg-gray-50 border-gray-200 dark:bg-gray-900 dark:border-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800'}`}
-               title="PCではホバー、スマホでは長押しで拡大表示。クリックでリアクションを切り替え"
-             >
-               {reaction.customEmoji ? (
-                 <img src={getCustomEmojiImageSrc(reaction.customEmoji)} alt={`:${reaction.customEmoji.name}:`} width={24} height={24} className="mr-1 inline-block h-6 w-6 rounded-sm object-contain align-middle" />
-               ) : (
-                 <span className="mr-1">{reaction.emoji}</span>
+             <div key={reaction.reactionKey} className="inline-flex items-center overflow-hidden rounded-full border border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-900">
+               <button
+                 type="button"
+                 onClick={(event) => handleReactionChipClick(event, reaction.reactionKey)}
+                 onMouseEnter={() => handleReactionMouseEnter(reaction)}
+                 onMouseLeave={handleReactionMouseLeave}
+                 onPointerDown={(event) => handleReactionPointerDown(event, reaction)}
+                 onPointerUp={handleReactionPointerUp}
+                 onPointerCancel={handleReactionPointerCancel}
+                 onPointerLeave={(event) => {
+                   if (event.pointerType !== 'mouse') handleReactionPointerCancel();
+                 }}
+                 className={`px-2 py-1 text-sm transition-colors ${reaction.hasReacted ? 'bg-indigo-50 text-indigo-700 dark:bg-indigo-950 dark:text-indigo-200' : 'text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800'}`}
+                 title="リアクションを切り替え"
+               >
+                 {reaction.customEmoji ? (
+                   <img src={getCustomEmojiImageSrc(reaction.customEmoji)} alt={`:${reaction.customEmoji.name}:`} width={24} height={24} className="mr-1 inline-block h-6 w-6 rounded-sm object-contain align-middle" />
+                 ) : (
+                   <span className="mr-1">{reaction.emoji}</span>
+                 )}
+                 <span className="text-xs font-semibold">{reaction.count}</span>
+               </button>
+               {reaction.customEmoji && (
+                 <button
+                   type="button"
+                   onClick={() => setEnlargedCustomEmoji(reaction.customEmoji ?? null)}
+                   className="border-l border-gray-200 px-2 py-1 text-[11px] font-semibold text-indigo-600 hover:bg-indigo-50 dark:border-gray-700 dark:text-indigo-300 dark:hover:bg-indigo-950"
+                   title={`:${reaction.customEmoji.name}: の画像を拡大表示`}
+                 >
+                   拡大
+                 </button>
                )}
-               <span className="text-xs font-semibold">{reaction.count}</span>
-             </button>
+             </div>
            ))}
            <button
              type="button"
@@ -620,6 +632,30 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
       </div>
     )}
 
+    {enlargedCustomEmoji && (
+      <div className="fixed inset-0 z-[120] flex items-center justify-center bg-black/70 p-4" role="dialog" aria-modal="true" aria-label="カスタム絵文字画像を拡大表示">
+        <div className="relative flex max-w-[90vw] flex-col items-center gap-3 rounded-3xl border border-gray-200 bg-white p-6 shadow-2xl dark:border-gray-700 dark:bg-gray-900">
+          <button
+            type="button"
+            onClick={() => setEnlargedCustomEmoji(null)}
+            className="absolute right-3 top-3 rounded-full p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+            aria-label="拡大画像を閉じる"
+          >
+            <X className="h-5 w-5" />
+          </button>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={getCustomEmojiImageSrc(enlargedCustomEmoji)}
+            alt={`:${enlargedCustomEmoji.name}:`}
+            width={192}
+            height={192}
+            className="h-48 w-48 rounded-xl object-contain"
+          />
+          <span className="text-sm font-semibold text-gray-700 dark:text-gray-200">:{enlargedCustomEmoji.name}:</span>
+        </div>
+      </div>
+    )}
+
     {showReactionPicker && !isGuest && (
       <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 p-4" role="dialog" aria-modal="true" aria-label="絵文字リアクションを選択">
         <div data-emoji-picker-panel className="flex max-h-[80vh] w-full max-w-xl flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-2xl dark:border-gray-700 dark:bg-gray-900">
@@ -643,15 +679,24 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
               {customEmojis.length > 0 && (
                 <div className="mb-3 grid grid-cols-8 gap-1 sm:grid-cols-10 md:grid-cols-12">
                   {customEmojis.map((customEmoji) => (
-                    <button
-                      key={customEmoji.id}
-                      type="button"
-                      onClick={() => handleReaction(`custom:${customEmoji.id}`, customEmoji)}
-                      className="rounded-lg p-2 hover:bg-gray-100 dark:hover:bg-gray-800"
-                      title={`:${customEmoji.name}: を追加`}
-                    >
-                      <img src={getCustomEmojiImageSrc(customEmoji)} alt={`:${customEmoji.name}:`} width={32} height={32} className="h-8 w-8 object-contain" />
-                    </button>
+                    <div key={customEmoji.id} className="flex flex-col items-center gap-1 rounded-lg p-1 hover:bg-gray-100 dark:hover:bg-gray-800">
+                      <button
+                        type="button"
+                        onClick={() => handleReaction(`custom:${customEmoji.id}`, customEmoji)}
+                        className="rounded-md p-1"
+                        title={`:${customEmoji.name}: を追加`}
+                      >
+                        <img src={getCustomEmojiImageSrc(customEmoji)} alt={`:${customEmoji.name}:`} width={32} height={32} className="h-8 w-8 object-contain" />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setEnlargedCustomEmoji(customEmoji)}
+                        className="rounded-full border border-indigo-200 px-2 py-0.5 text-[10px] font-semibold text-indigo-600 hover:bg-indigo-50 dark:border-indigo-700 dark:text-indigo-300 dark:hover:bg-indigo-950"
+                        title={`:${customEmoji.name}: の画像を拡大表示`}
+                      >
+                        拡大
+                      </button>
+                    </div>
                   ))}
                 </div>
               )}


### PR DESCRIPTION
## Summary
- Adds an enlarged reaction preview popup for post emoji reactions
- Shows the popup on hover for fine-pointer desktop devices
- Shows the popup on long press for touch devices without toggling the reaction

## Verification
- `npx tsc --noEmit`
- `npx eslint components/SinglePost.tsx` (0 errors; existing warnings remain)
- `npm run lint` still fails due to pre-existing unrelated lint errors elsewhere in the repo