### PR TITLE
fix: dismiss reaction preview after click

### DIFF
--- a/components/Feed.tsx
+++ b/components/Feed.tsx
@@ -336,6 +336,8 @@ export default function Feed({ initialPosts, currentUserId, feedType, searchQuer
       alert('リアクションには絵文字1つだけを選択してください。');
       return;
     }
+    clearCustomEmojiPreviewTimers();
+    setEnlargedCustomEmoji(null);
     setShowReactionPickerForPostId(null);
     setPosts((current) =>
       current.map((p) =>
@@ -418,6 +420,8 @@ export default function Feed({ initialPosts, currentUserId, feedType, searchQuer
       suppressCustomEmojiClickRef.current = false;
       return;
     }
+    clearCustomEmojiPreviewTimers();
+    setEnlargedCustomEmoji(null);
     callback();
   };
 

--- a/components/SinglePost.tsx
+++ b/components/SinglePost.tsx
@@ -156,6 +156,10 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
       alert('リアクションには絵文字1つだけを選択してください。');
       return;
     }
+    clearReactionPreviewTimers();
+    clearCustomEmojiPreviewTimers();
+    setPreviewReaction(null);
+    setEnlargedCustomEmoji(null);
     setShowReactionPicker(false);
     setPost((current) => ({
       ...current,
@@ -295,6 +299,8 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
       suppressReactionClickRef.current = false;
       return;
     }
+    clearReactionPreviewTimers();
+    setPreviewReaction(null);
     handleReaction(reactionKey);
   };
 
@@ -305,6 +311,8 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
       suppressCustomEmojiClickRef.current = false;
       return;
     }
+    clearCustomEmojiPreviewTimers();
+    setEnlargedCustomEmoji(null);
     handleReaction(`custom:${customEmoji.id}`, customEmoji);
   };
 


### PR DESCRIPTION
## Summary
- Dismiss custom emoji preview state before applying a reaction
- Clear hover preview timers when clicking reaction chips or picker emoji
- Prevent the PC hover preview chip from remaining after adding/toggling a reaction

## Test Plan
- npx tsc --noEmit
- npx eslint components/Feed.tsx components/SinglePost.tsx
