### PR TITLE
fix: improve profile navigation performance

### DIFF
--- a/app/profile/ProfileClient.tsx
+++ b/app/profile/ProfileClient.tsx
@@ -1,21 +1,31 @@
 'use client';
 
 import Link from 'next/link';
+import dynamic from 'next/dynamic';
 import { Grid, Heart, Settings, ShieldCheck, MoreHorizontal, Book } from 'lucide-react';
 import { useState, useTransition } from 'react';
-import Feed from '@/components/Feed';
 import { useRouter } from 'next/navigation';
-import VerificationModal from '@/components/VerificationModal';
 import ProfileHeader from '@/components/ProfileHeader';
 import { Spinner } from '@/components/ui/spinner';
-import { DiaryGrid } from '../diary/DiaryGrid';
+import { DiaryGrid, type DiaryEntry } from '../diary/DiaryGrid';
+import type { PostReactionSummary } from '@/lib/reactions';
+
+const Feed = dynamic(() => import('@/components/Feed'), {
+  loading: () => (
+    <div className="flex justify-center p-10">
+      <Spinner />
+    </div>
+  ),
+});
+
+const VerificationModal = dynamic(() => import('@/components/VerificationModal'));
 
 type ProfileClientProps = {
-  user: any;
-  currentUser: any;
-  posts: any[];
-  likedPosts: any[];
-  diaries?: any[];
+  user: ProfileUser;
+  currentUser: { id: number; username: string; avatarUrl?: string | null } | null;
+  posts: ProfilePost[];
+  likedPosts: ProfilePost[];
+  diaries?: DiaryEntry[];
   initialStatus: {
       isFollowing: boolean;
       isMuted: boolean;
@@ -26,6 +36,50 @@ type ProfileClientProps = {
       silver: number;
       bronze: number;
   };
+};
+
+type ProfileUser = {
+  id: number;
+  username: string;
+  avatarUrl: string | null;
+  isVerified: boolean;
+  isGold: boolean;
+  roles: string[];
+  bio: string | null;
+  oshi: string | null;
+  _count: {
+    followers: number;
+    following: number;
+  };
+};
+
+type ProfilePost = {
+  id: number;
+  imageUrl?: string;
+  mediaType?: 'IMAGE' | 'VIDEO';
+  thumbnailUrl?: string | null;
+  comment: string | null;
+  isSpoiler?: boolean;
+  createdAt: Date;
+  userId: number;
+  user?: {
+    username: string;
+    avatarUrl: string | null;
+    isVerified?: boolean;
+    isGold?: boolean;
+    roles?: string[];
+  };
+  likesCount: number;
+  hasLiked: boolean;
+  comments?: {
+    id: number;
+    text: string;
+    userId: number;
+    user: { username: string; avatarUrl: string | null };
+  }[];
+  reactions?: PostReactionSummary[];
+  hashtags?: { name: string }[];
+  images?: { id: number; order: number; url?: string }[];
 };
 
 export default function ProfileClient({ user, currentUser, posts, likedPosts = [], diaries = [], initialStatus, trophies }: ProfileClientProps) {

--- a/app/profile/loading.tsx
+++ b/app/profile/loading.tsx
@@ -1,0 +1,7 @@
+export default function Loading() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-white dark:bg-black">
+      <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-gray-900 dark:border-white" />
+    </div>
+  );
+}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -3,8 +3,7 @@ import { getSession } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import ProfileClient from './ProfileClient';
 import Link from 'next/link';
-import { ArrowLeft, LogOut } from 'lucide-react';
-import { logout } from '@/app/actions/logout';
+import { ArrowLeft } from 'lucide-react';
 import { getUserTrophies } from '@/app/actions/trophy';
 import { getDiariesByUser } from '@/app/actions/diary';
 import { buildPostReactionSummaries } from '@/lib/reactions';
@@ -46,11 +45,10 @@ export default async function ProfilePage() {
       avatarUrl: userData?.avatarUrl ? `/api/avatar/${userData.username}?v=${userData.updatedAt.getTime()}` : null
   };
 
-  const trophies = await getUserTrophies(session.id);
-  const diaries = await getDiariesByUser(session.id);
-
-  // Fetch my posts
-  const myPostsData = await db.post.findMany({
+  const [trophies, diaries, myPostsData, likedPostsData] = await Promise.all([
+    getUserTrophies(session.id),
+    getDiariesByUser(session.id),
+    db.post.findMany({
     take: 12,
     where: { userId: session.id },
     orderBy: { createdAt: 'desc' },
@@ -113,33 +111,9 @@ export default async function ProfilePage() {
           select: { userId: true }
       }
     },
-  });
+  }),
 
-  const myPosts = myPostsData.map(post => ({
-      ...post,
-      imageUrl: post.imageUrl && post.imageUrl.startsWith('http')
-          ? post.imageUrl
-          : `/api/image/${post.id}.jpg`,
-      thumbnailUrl: post.thumbnailUrl
-        ? (post.thumbnailUrl.startsWith('http') ? post.thumbnailUrl : `/api/post_thumbnail/${post.id}.jpg`)
-        : null,
-      images: post.images.map(img => ({
-        ...img,
-        url: img.url && img.url.startsWith('http') ? img.url : `/api/post_image/${img.id}.jpg`
-      })),
-      user: {
-          ...post.user,
-          avatarUrl: post.user.avatarUrl ? `/api/avatar/${post.user.username}?v=${post.user.updatedAt.getTime()}` : null
-      },
-      likesCount: post._count.likes,
-      hasLiked: post.likes.length > 0,
-      reactions: buildPostReactionSummaries(post.reactions, session.id),
-      likes: undefined,
-      _count: undefined
-  }));
-
-  // Fetch liked posts
-  const likedPostsData = await db.like.findMany({
+    db.like.findMany({
       take: 12,
       where: { userId: session.id },
       orderBy: { createdAt: 'desc' },
@@ -206,7 +180,31 @@ export default async function ProfilePage() {
               }
           }
       }
-  });
+  }),
+  ]);
+
+  const myPosts = myPostsData.map(post => ({
+      ...post,
+      imageUrl: post.imageUrl && post.imageUrl.startsWith('http')
+          ? post.imageUrl
+          : `/api/image/${post.id}.jpg`,
+      thumbnailUrl: post.thumbnailUrl
+        ? (post.thumbnailUrl.startsWith('http') ? post.thumbnailUrl : `/api/post_thumbnail/${post.id}.jpg`)
+        : null,
+      images: post.images.map(img => ({
+        ...img,
+        url: img.url && img.url.startsWith('http') ? img.url : `/api/post_image/${img.id}.jpg`
+      })),
+      user: {
+          ...post.user,
+          avatarUrl: post.user.avatarUrl ? `/api/avatar/${post.user.username}?v=${post.user.updatedAt.getTime()}` : null
+      },
+      likesCount: post._count.likes,
+      hasLiked: post.likes.length > 0,
+      reactions: buildPostReactionSummaries(post.reactions, session.id),
+      likes: undefined,
+      _count: undefined
+  }));
 
   const likedPosts = likedPostsData.map(item => ({
       ...item.post,

--- a/components/EditProfileForm.tsx
+++ b/components/EditProfileForm.tsx
@@ -1,13 +1,36 @@
 'use client';
 
 import { useActionState, useState, useRef, useEffect, useCallback } from 'react';
+import dynamic from 'next/dynamic';
 import { updateProfile } from '@/app/actions/user';
 import { Camera, Check, X } from 'lucide-react';
-import Cropper from 'react-easy-crop';
 import { getCroppedImg } from '@/lib/image';
 import { uploadImageToSupabase } from '@/lib/client-upload';
 import { Spinner } from '@/components/ui/spinner';
 import { SelfRoleSelector } from '@/components/SelfRoleSelector';
+
+type LazyCropperProps = {
+  image: string;
+  crop: { x: number; y: number };
+  zoom: number;
+  aspect: number;
+  cropShape: 'rect' | 'round';
+  showGrid: boolean;
+  onCropChange: (crop: { x: number; y: number }) => void;
+  onCropComplete: (croppedArea: Area, croppedAreaPixels: Area) => void;
+  onZoomChange: (zoom: number) => void;
+};
+
+const Cropper = dynamic<LazyCropperProps>(
+  () =>
+    import('react-easy-crop').then((mod) => {
+      const CropperComponent = mod.default;
+      return function LazyCropper(props: LazyCropperProps) {
+        return <CropperComponent {...props} />;
+      };
+    }),
+  { ssr: false }
+);
 
 type User = {
     username: string;

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -17,7 +17,7 @@ export const db =
   globalForPrisma.prisma ||
   new PrismaClient({
     adapter,
-    log: ['query'],
+    log: process.env.NODE_ENV === 'development' ? ['query'] : [],
   });
 
 if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = db;


### PR DESCRIPTION
## Summary
- Parallelize independent profile page data fetches to reduce server navigation latency
- Add a profile loading fallback so navigation gives immediate feedback
- Lazy-load the heavy Feed, VerificationModal, and avatar cropper bundles
- Disable Prisma query logging outside development

## Test Plan
- npx tsc --noEmit
- npx eslint app/profile/page.tsx app/profile/ProfileClient.tsx app/profile/loading.tsx components/EditProfileForm.tsx lib/db.ts
- npm run build (fails during page-data collection because SESSION_SECRET is not set in this environment; compile and TypeScript stages passed before the env failure)
