### PR TITLE
fix: limit notifications list

### DIFF
--- a/app/actions/notification.ts
+++ b/app/actions/notification.ts
@@ -6,7 +6,7 @@ import { revalidatePath } from 'next/cache';
 import { z } from 'zod';
 import { NotificationType } from '@prisma/client';
 
-export async function getNotifications() {
+export async function getNotifications(limit = 10) {
   const session = await getSession();
   if (!session || !session.id) {
     return [];
@@ -20,6 +20,7 @@ export async function getNotifications() {
       orderBy: {
         createdAt: 'desc',
       },
+      take: limit,
     });
     return notifications;
   } catch (error) {


### PR DESCRIPTION
## Summary
- Limit the notifications page query to the latest 10 notifications
- Keep existing newest-first ordering and read-marking behavior

## Test Plan
- [x] `npx tsc --noEmit`
- [x] `npx eslint app/actions/notification.ts app/notifications/page.tsx`
