### PR TITLE
fix: keep comment loading active after loading more posts

### DIFF
--- a/components/Feed.tsx
+++ b/components/Feed.tsx
@@ -237,7 +237,10 @@ export default function Feed({ initialPosts, currentUserId, feedType, searchQuer
   useEffect(() => {
     if (!selectedPostId) return;
 
-    const post = posts.find((p) => p.id === selectedPostId);
+    // Do not depend on the whole posts array here. Loading more posts updates
+    // posts while the modal comment request is in flight, and the cleanup would
+    // abort the request before the comments can render.
+    const post = postsRef.current.find((p) => p.id === selectedPostId);
     if (!post || post.comments !== undefined) return;
 
     let isActive = true;
@@ -274,7 +277,7 @@ export default function Feed({ initialPosts, currentUserId, feedType, searchQuer
       }
       window.clearTimeout(timeoutId);
     };
-  }, [selectedPostId, posts]);
+  }, [selectedPostId]);
 
   const handlePostClick = async (post: Post) => {
     if (post.isSpoiler) {


### PR DESCRIPTION
## Summary
- Keep the modal comment fetch independent from unrelated `posts` state changes
- Use the existing `postsRef` snapshot so pressing `もっと見る` no longer aborts an in-flight comment request

## Test Plan
- `npx eslint components/Feed.tsx` (passes with existing warnings)
- `npx tsc --noEmit`
- `npm run build` (fails before completion because `SESSION_SECRET` is not set in this environment)
