### PR TITLE
feat: edit post text and view reactions

### DIFF
--- a/app/actions/post.ts
+++ b/app/actions/post.ts
@@ -128,7 +128,7 @@ export async function fetchFeedPosts({
         },
         // Removed comments fetch for feed optimization
         reactions: {
-          select: { reactionKey: true, userId: true, customEmoji: { select: { id: true, name: true, imageUrl: true, width: true, height: true } } },
+          select: { reactionKey: true, userId: true, user: { select: { id: true, username: true, avatarUrl: true, updatedAt: true } }, customEmoji: { select: { id: true, name: true, imageUrl: true, width: true, height: true } } },
         },
         _count: {
           select: { likes: true },
@@ -227,7 +227,7 @@ export async function fetchUserPosts({
           },
         },
         reactions: {
-          select: { reactionKey: true, userId: true, customEmoji: { select: { id: true, name: true, imageUrl: true, width: true, height: true } } },
+          select: { reactionKey: true, userId: true, user: { select: { id: true, username: true, avatarUrl: true, updatedAt: true } }, customEmoji: { select: { id: true, name: true, imageUrl: true, width: true, height: true } } },
         },
         _count: {
           select: { likes: true },
@@ -325,7 +325,7 @@ export async function fetchLikedPosts({
                   }
               },
               reactions: {
-                  select: { reactionKey: true, userId: true, customEmoji: { select: { id: true, name: true, imageUrl: true, width: true, height: true } } }
+                  select: { reactionKey: true, userId: true, user: { select: { id: true, username: true, avatarUrl: true, updatedAt: true } }, customEmoji: { select: { id: true, name: true, imageUrl: true, width: true, height: true } } }
               },
               _count: {
                   select: { likes: true }
@@ -486,6 +486,44 @@ export async function createPost(prevState: unknown, formData: FormData) {
   revalidatePath("/");
   revalidatePath("/profile");
   redirect("/");
+}
+
+export async function updatePostComment(postId: number, comment: string) {
+  const session = await getSession();
+  if (!session) return { message: "Unauthorized" };
+
+  const normalizedComment = comment.trim();
+  if (normalizedComment.length > 173) {
+    return { message: "コメントが長すぎます(173文字まで)" };
+  }
+
+  const post = await db.post.findUnique({
+    where: { id: postId },
+    select: { userId: true },
+  });
+
+  if (!post) {
+    return { message: "Post not found" };
+  }
+
+  if (post.userId !== session.id) {
+    return { message: "Forbidden" };
+  }
+
+  try {
+    await db.post.update({
+      where: { id: postId },
+      data: { comment: normalizedComment || null },
+    });
+  } catch (error) {
+    console.error("Failed to update post comment:", error);
+    return { message: "Failed to update post" };
+  }
+
+  revalidatePath("/");
+  revalidatePath("/profile");
+  revalidatePath(`/p/${postId}`);
+  return { success: true, comment: normalizedComment || null };
 }
 
 export async function toggleLike(postId: number) {

--- a/app/p/[id]/page.tsx
+++ b/app/p/[id]/page.tsx
@@ -81,7 +81,7 @@ export default async function PostPage({ params }: { params: Promise<{ id: strin
           }
       },
       reactions: {
-          select: { reactionKey: true, userId: true, customEmoji: { select: { id: true, name: true, imageUrl: true, width: true, height: true } } }
+          select: { reactionKey: true, userId: true, user: { select: { id: true, username: true, avatarUrl: true, updatedAt: true } }, customEmoji: { select: { id: true, name: true, imageUrl: true, width: true, height: true } } }
       },
       _count: {
           select: { likes: true }

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -101,7 +101,7 @@ export default async function ProfilePage() {
           }
       },
       reactions: {
-          select: { reactionKey: true, userId: true, customEmoji: { select: { id: true, name: true, imageUrl: true, width: true, height: true } } }
+          select: { reactionKey: true, userId: true, user: { select: { id: true, username: true, avatarUrl: true, updatedAt: true } }, customEmoji: { select: { id: true, name: true, imageUrl: true, width: true, height: true } } }
       },
       _count: {
           select: { likes: true }
@@ -168,7 +168,7 @@ export default async function ProfilePage() {
                     }
                 },
                 reactions: {
-                    select: { reactionKey: true, userId: true, customEmoji: { select: { id: true, name: true, imageUrl: true, width: true, height: true } } }
+                    select: { reactionKey: true, userId: true, user: { select: { id: true, username: true, avatarUrl: true, updatedAt: true } }, customEmoji: { select: { id: true, name: true, imageUrl: true, width: true, height: true } } }
                 },
                 _count: {
                     select: { likes: true }

--- a/app/users/[username]/page.tsx
+++ b/app/users/[username]/page.tsx
@@ -122,7 +122,7 @@ export default async function UserPage({ params }: { params: Promise<{ username:
           }
       },
       reactions: {
-          select: { reactionKey: true, userId: true, customEmoji: { select: { id: true, name: true, imageUrl: true, width: true, height: true } } }
+          select: { reactionKey: true, userId: true, user: { select: { id: true, username: true, avatarUrl: true, updatedAt: true } }, customEmoji: { select: { id: true, name: true, imageUrl: true, width: true, height: true } } }
       },
       _count: {
           select: { likes: true }
@@ -205,7 +205,7 @@ export default async function UserPage({ params }: { params: Promise<{ username:
                         }
                     },
                     reactions: {
-                        select: { reactionKey: true, userId: true, customEmoji: { select: { id: true, name: true, imageUrl: true, width: true, height: true } } }
+                        select: { reactionKey: true, userId: true, user: { select: { id: true, username: true, avatarUrl: true, updatedAt: true } }, customEmoji: { select: { id: true, name: true, imageUrl: true, width: true, height: true } } }
                     },
                     _count: {
                         select: { likes: true }

--- a/components/Feed.tsx
+++ b/components/Feed.tsx
@@ -957,7 +957,7 @@ export default function Feed({ initialPosts, currentUserId, feedType, searchQuer
                     <button
                       type="button"
                       onClick={() => setReactionViewer(reaction)}
-                      className={`py-1 pl-1 pr-2 text-xs font-semibold transition-colors ${reaction.hasReacted ? 'hover:bg-indigo-100 dark:hover:bg-indigo-900' : 'hover:bg-gray-100 dark:hover:bg-gray-800'}`}
+                      className={`border-l border-gray-300 py-1 pl-2 pr-2 text-xs font-semibold transition-colors dark:border-gray-600 ${reaction.hasReacted ? 'hover:bg-indigo-100 dark:hover:bg-indigo-900' : 'hover:bg-gray-100 dark:hover:bg-gray-800'}`}
                       aria-label={`${reaction.count}人のリアクションを表示`}
                     >
                       {reaction.count}

--- a/components/Feed.tsx
+++ b/components/Feed.tsx
@@ -767,8 +767,8 @@ export default function Feed({ initialPosts, currentUserId, feedType, searchQuer
             )}
 
             <div className="p-4 overflow-y-auto flex-1 min-h-0 dark:text-gray-100">
-              <div className="flex items-center justify-between mb-2">
-                <div className="flex items-center gap-3">
+              <div className="mb-2 flex flex-wrap items-center justify-between gap-x-3 gap-y-2">
+                <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-3 gap-y-2">
                     <button
                         onClick={() => handleLike(selectedPost)}
                         className={`flex items-center gap-1.5 transition-colors group ${isGuest ? 'cursor-not-allowed opacity-50' : ''}`}
@@ -796,8 +796,8 @@ export default function Feed({ initialPosts, currentUserId, feedType, searchQuer
                     </button>
                     {/* Username link with Avatar */}
                     {selectedPost.user && (
-                        <div className="flex items-center gap-2">
-                             <div className="w-6 h-6 rounded-full bg-gray-200 dark:bg-gray-700 overflow-hidden flex-shrink-0">
+                        <div className="flex min-w-0 flex-wrap items-center gap-2">
+                             <div className="h-6 w-6 flex-shrink-0 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
                                 {selectedPost.user.avatarUrl ? (
                                     // eslint-disable-next-line @next/next/no-img-element
                                     <img
@@ -812,7 +812,7 @@ export default function Feed({ initialPosts, currentUserId, feedType, searchQuer
                                     </div>
                                 )}
                              </div>
-                             <Link href={`/users/${selectedPost.user.username}`} className="text-sm font-semibold hover:underline">
+                             <Link href={`/users/${selectedPost.user.username}`} className="min-w-0 max-w-[10rem] truncate text-sm font-semibold hover:underline sm:max-w-none">
                                 @{selectedPost.user.username}
                              </Link>
                              {selectedPost.user.isGold ? (
@@ -821,7 +821,7 @@ export default function Feed({ initialPosts, currentUserId, feedType, searchQuer
                                <BadgeCheck className="w-4 h-4 text-blue-500" />
                              ) : null}
                              {selectedPost.user.roles?.map(roleId => (
-                                <div key={roleId} className="scale-75 origin-left flex item-center">
+                                <div key={roleId} className="flex origin-left scale-75 items-center">
                                     <RoleBadge roleId={roleId} />
                                 </div>
                              ))}
@@ -830,7 +830,7 @@ export default function Feed({ initialPosts, currentUserId, feedType, searchQuer
                 </div>
 
                 {!isGuest && currentUserId === selectedPost.userId && (
-                   <div className="flex items-center gap-2">
+                   <div className="ml-auto flex shrink-0 items-center gap-2">
                      <button
                       type="button"
                       onClick={() => startEditingPostComment(selectedPost)}

--- a/components/Feed.tsx
+++ b/components/Feed.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { useState, useEffect, useRef, type MouseEvent, type PointerEvent } from 'react';
-import { Heart, Plus, X, Trash2, BadgeCheck, Loader2, Share2, Send, User as UserIcon, Layers, AlertTriangle, Play, CornerDownRight } from 'lucide-react';
+import { Heart, Plus, X, Trash2, BadgeCheck, Loader2, Share2, Send, User as UserIcon, Layers, AlertTriangle, Play, CornerDownRight, Pencil } from 'lucide-react';
 import Link from 'next/link';
 import { useSearchParams, usePathname } from 'next/navigation';
-import { toggleLike, toggleReaction, deletePost, fetchFeedPosts, fetchUserPosts, fetchLikedPosts } from '@/app/actions/post';
+import { toggleLike, toggleReaction, deletePost, updatePostComment, fetchFeedPosts, fetchUserPosts, fetchLikedPosts } from '@/app/actions/post';
 import { addComment, deleteComment } from '@/app/actions/comment';
 import { RoleBadge } from '@/components/RoleBadge';
 import { ImageCarousel } from '@/components/ImageCarousel';
@@ -78,6 +78,7 @@ function toggleReactionSummary(
       count: 1,
       hasReacted: true,
       customEmoji,
+      users: [],
     });
   }
 
@@ -123,6 +124,10 @@ export default function Feed({ initialPosts, currentUserId, feedType, searchQuer
   const [customEmojis, setCustomEmojis] = useState<CustomEmojiSummary[]>([]);
   const [customEmojiError, setCustomEmojiError] = useState<string | null>(null);
   const [enlargedCustomEmoji, setEnlargedCustomEmoji] = useState<CustomEmojiSummary | null>(null);
+  const [editingPostId, setEditingPostId] = useState<number | null>(null);
+  const [editCommentText, setEditCommentText] = useState('');
+  const [isSavingPostComment, setIsSavingPostComment] = useState(false);
+  const [reactionViewer, setReactionViewer] = useState<PostReactionSummary | null>(null);
   const commentInputRef = useRef<HTMLInputElement>(null);
   const customEmojiPreviewTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const customEmojiPreviewDismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -472,6 +477,38 @@ export default function Feed({ initialPosts, currentUserId, feedType, searchQuer
     setIsDeleting(false);
   };
 
+  const startEditingPostComment = (post: Post) => {
+    setEditingPostId(post.id);
+    setEditCommentText(post.comment ?? '');
+  };
+
+  const cancelEditingPostComment = () => {
+    setEditingPostId(null);
+    setEditCommentText('');
+  };
+
+  const handleSavePostComment = async (postId: number) => {
+    if (editCommentText.trim().length > 173) {
+      alert('コメントが長すぎます(173文字まで)');
+      return;
+    }
+
+    setIsSavingPostComment(true);
+    const result = await updatePostComment(postId, editCommentText);
+    setIsSavingPostComment(false);
+
+    if (result?.success) {
+      setPosts((current) =>
+        current.map((post) =>
+          post.id === postId ? { ...post, comment: result.comment } : post
+        )
+      );
+      cancelEditingPostComment();
+    } else {
+      alert(result?.message || '投稿の編集に失敗しました');
+    }
+  };
+
   const loadMore = async () => {
       if (isLoadingMore || !feedType) return;
       
@@ -793,21 +830,68 @@ export default function Feed({ initialPosts, currentUserId, feedType, searchQuer
                 </div>
 
                 {!isGuest && currentUserId === selectedPost.userId && (
-                   <button
-                    onClick={() => handleDelete(selectedPost.id)}
-                    disabled={isDeleting}
-                    className="text-gray-400 dark:text-gray-500 hover:text-red-500 disabled:opacity-50"
-                   >
-                     <Trash2 className="w-5 h-5" />
-                   </button>
+                   <div className="flex items-center gap-2">
+                     <button
+                      type="button"
+                      onClick={() => startEditingPostComment(selectedPost)}
+                      disabled={isDeleting || isSavingPostComment}
+                      className="text-gray-400 dark:text-gray-500 hover:text-indigo-500 disabled:opacity-50"
+                      aria-label="投稿本文を編集"
+                     >
+                       <Pencil className="w-5 h-5" />
+                     </button>
+                     <button
+                      type="button"
+                      onClick={() => handleDelete(selectedPost.id)}
+                      disabled={isDeleting}
+                      className="text-gray-400 dark:text-gray-500 hover:text-red-500 disabled:opacity-50"
+                      aria-label="投稿を削除"
+                     >
+                       <Trash2 className="w-5 h-5" />
+                     </button>
+                   </div>
                 )}
               </div>
               
-              {selectedPost.comment && (
+              {editingPostId === selectedPost.id ? (
+                <div className="mb-3 rounded-lg border border-gray-200 p-3 dark:border-gray-700">
+                  <textarea
+                    value={editCommentText}
+                    onChange={(event) => setEditCommentText(event.target.value)}
+                    maxLength={173}
+                    rows={4}
+                    className="w-full resize-none rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+                    placeholder="本文を入力"
+                  />
+                  <div className="mt-2 flex items-center justify-between">
+                    <span className={`text-[10px] ${editCommentText.trim().length >= 173 ? 'text-red-500' : 'text-gray-400'}`}>
+                      {editCommentText.trim().length}/173
+                    </span>
+                    <div className="flex gap-2">
+                      <button
+                        type="button"
+                        onClick={cancelEditingPostComment}
+                        disabled={isSavingPostComment}
+                        className="rounded-full px-3 py-1 text-xs font-semibold text-gray-500 hover:bg-gray-100 disabled:opacity-50 dark:text-gray-300 dark:hover:bg-gray-800"
+                      >
+                        キャンセル
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handleSavePostComment(selectedPost.id)}
+                        disabled={isSavingPostComment || editCommentText.trim().length > 173}
+                        className="rounded-full bg-indigo-600 px-3 py-1 text-xs font-semibold text-white hover:bg-indigo-500 disabled:opacity-50"
+                      >
+                        {isSavingPostComment ? '保存中...' : '保存'}
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              ) : selectedPost.comment ? (
                 <p className="text-gray-900 dark:text-gray-100 break-words mb-2">
                     <Linkify>{selectedPost.comment}</Linkify>
                 </p>
-              )}
+              ) : null}
 
               {selectedPost.hashtags && selectedPost.hashtags.length > 0 && (
                 <div className="flex flex-wrap gap-1 mb-2">
@@ -841,33 +925,44 @@ export default function Feed({ initialPosts, currentUserId, feedType, searchQuer
               <div className="space-y-3 border-t dark:border-gray-800 pt-3">
                 <div className="flex flex-wrap items-center gap-1 pb-3 border-b border-gray-100 dark:border-gray-800" data-emoji-picker="unicode-emoji-grid">
                 {(selectedPost.reactions || []).map((reaction) => (
-                  <button
+                  <div
                     key={reaction.reactionKey}
-                    type="button"
-                    onClick={(event) => handleCustomEmojiClick(event, () => handleReaction(selectedPost, reaction.reactionKey))}
-                    onMouseEnter={() => reaction.customEmoji && handleCustomEmojiMouseEnter(reaction.customEmoji)}
-                    onMouseLeave={reaction.customEmoji ? handleCustomEmojiMouseLeave : undefined}
-                    onPointerDown={(event) => {
-                      if (reaction.customEmoji) handleCustomEmojiPointerDown(event, reaction.customEmoji);
-                    }}
-                    onPointerUp={reaction.customEmoji ? handleCustomEmojiPointerUp : undefined}
-                    onPointerCancel={reaction.customEmoji ? handleCustomEmojiPointerCancel : undefined}
-                    onPointerLeave={(event) => {
-                      if (event.pointerType !== 'mouse' && reaction.customEmoji) handleCustomEmojiPointerCancel();
-                    }}
-                    onContextMenu={(event) => {
-                      if (reaction.customEmoji) event.preventDefault();
-                    }}
-                    className={`select-none px-2 py-1 rounded-full border text-sm transition-colors [-webkit-touch-callout:none] ${reaction.hasReacted ? 'bg-indigo-50 border-indigo-300 text-indigo-700 dark:bg-indigo-950 dark:border-indigo-700 dark:text-indigo-200' : 'bg-gray-50 border-gray-200 dark:bg-gray-900 dark:border-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800'}`}
-                    aria-label={reaction.customEmoji ? `:${reaction.customEmoji.name}: のリアクションを切り替え` : `${reaction.emoji} のリアクションを切り替え`}
+                    className={`inline-flex overflow-hidden rounded-full border text-sm transition-colors ${reaction.hasReacted ? 'bg-indigo-50 border-indigo-300 text-indigo-700 dark:bg-indigo-950 dark:border-indigo-700 dark:text-indigo-200' : 'bg-gray-50 border-gray-200 dark:bg-gray-900 dark:border-gray-700 dark:text-gray-200'}`}
                   >
-                    {reaction.customEmoji ? (
-                      <img src={getCustomEmojiImageSrc(reaction.customEmoji)} alt={`:${reaction.customEmoji.name}:`} width={24} height={24} draggable={false} className="mr-1 inline-block h-6 w-6 select-none rounded-sm object-contain align-middle [-webkit-touch-callout:none]" />
-                    ) : (
-                      <span className="mr-1">{reaction.emoji}</span>
-                    )}
-                    <span className="text-xs font-semibold">{reaction.count}</span>
-                  </button>
+                    <button
+                      type="button"
+                      onClick={(event) => handleCustomEmojiClick(event, () => handleReaction(selectedPost, reaction.reactionKey))}
+                      onMouseEnter={() => reaction.customEmoji && handleCustomEmojiMouseEnter(reaction.customEmoji)}
+                      onMouseLeave={reaction.customEmoji ? handleCustomEmojiMouseLeave : undefined}
+                      onPointerDown={(event) => {
+                        if (reaction.customEmoji) handleCustomEmojiPointerDown(event, reaction.customEmoji);
+                      }}
+                      onPointerUp={reaction.customEmoji ? handleCustomEmojiPointerUp : undefined}
+                      onPointerCancel={reaction.customEmoji ? handleCustomEmojiPointerCancel : undefined}
+                      onPointerLeave={(event) => {
+                        if (event.pointerType !== 'mouse' && reaction.customEmoji) handleCustomEmojiPointerCancel();
+                      }}
+                      onContextMenu={(event) => {
+                        if (reaction.customEmoji) event.preventDefault();
+                      }}
+                      className={`select-none py-1 pl-2 pr-1 transition-colors [-webkit-touch-callout:none] ${reaction.hasReacted ? 'hover:bg-indigo-100 dark:hover:bg-indigo-900' : 'hover:bg-gray-100 dark:hover:bg-gray-800'}`}
+                      aria-label={reaction.customEmoji ? `:${reaction.customEmoji.name}: のリアクションを切り替え` : `${reaction.emoji} のリアクションを切り替え`}
+                    >
+                      {reaction.customEmoji ? (
+                        <img src={getCustomEmojiImageSrc(reaction.customEmoji)} alt={`:${reaction.customEmoji.name}:`} width={24} height={24} draggable={false} className="inline-block h-6 w-6 select-none rounded-sm object-contain align-middle [-webkit-touch-callout:none]" />
+                      ) : (
+                        <span>{reaction.emoji}</span>
+                      )}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setReactionViewer(reaction)}
+                      className={`py-1 pl-1 pr-2 text-xs font-semibold transition-colors ${reaction.hasReacted ? 'hover:bg-indigo-100 dark:hover:bg-indigo-900' : 'hover:bg-gray-100 dark:hover:bg-gray-800'}`}
+                      aria-label={`${reaction.count}人のリアクションを表示`}
+                    >
+                      {reaction.count}
+                    </button>
+                  </div>
                 ))}
                 <button
                   type="button"
@@ -971,6 +1066,57 @@ export default function Feed({ initialPosts, currentUserId, feedType, searchQuer
                     </p>
                 </div>
             )}
+          </div>
+        </div>
+      )}
+
+      {reactionViewer && (
+        <div className="fixed inset-0 z-[110] flex items-center justify-center bg-black/50 p-4" role="dialog" aria-modal="true" aria-label="リアクションしたユーザー">
+          <div className="w-full max-w-sm overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-2xl dark:border-gray-700 dark:bg-gray-900">
+            <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3 dark:border-gray-700">
+              <div className="flex items-center gap-2 text-sm font-semibold text-gray-900 dark:text-gray-100">
+                {reactionViewer.customEmoji ? (
+                  <img src={getCustomEmojiImageSrc(reactionViewer.customEmoji)} alt={`:${reactionViewer.customEmoji.name}:`} width={24} height={24} className="h-6 w-6 rounded-sm object-contain" />
+                ) : (
+                  <span className="text-xl">{reactionViewer.emoji}</span>
+                )}
+                <span>{reactionViewer.count}人</span>
+              </div>
+              <button
+                type="button"
+                onClick={() => setReactionViewer(null)}
+                className="rounded-full p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+                aria-label="閉じる"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+            <div className="max-h-[60vh] overflow-y-auto p-2">
+              {reactionViewer.users.map((user) => (
+                <Link
+                  key={user.id}
+                  href={`/users/${user.username}`}
+                  onClick={() => setReactionViewer(null)}
+                  className="flex items-center gap-3 rounded-xl px-3 py-2 hover:bg-gray-100 dark:hover:bg-gray-800"
+                >
+                  <div className="h-9 w-9 flex-shrink-0 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
+                    {user.avatarUrl ? (
+                      <img src={user.avatarUrl} alt={user.username} className="h-full w-full object-cover" />
+                    ) : (
+                      <div className="flex h-full w-full items-center justify-center text-gray-500 dark:text-gray-300">
+                        <UserIcon className="h-5 w-5" />
+                      </div>
+                    )}
+                  </div>
+                  <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">@{user.username}</span>
+                </Link>
+              ))}
+              {reactionViewer.users.length < reactionViewer.count && (
+                <p className="px-3 py-2 text-xs text-gray-500 dark:text-gray-400">
+                  ほか{reactionViewer.count - reactionViewer.users.length}人
+                </p>
+              )}
+            </div>
           </div>
         </div>
       )}

--- a/components/SinglePost.tsx
+++ b/components/SinglePost.tsx
@@ -681,7 +681,7 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
                <button
                  type="button"
                  onClick={() => setReactionViewer(reaction)}
-                 className={`py-1 pl-1 pr-2 text-xs font-semibold transition-colors ${reaction.hasReacted ? 'hover:bg-indigo-100 dark:hover:bg-indigo-900' : 'hover:bg-gray-100 dark:hover:bg-gray-800'}`}
+                 className={`border-l border-gray-300 py-1 pl-2 pr-2 text-xs font-semibold transition-colors dark:border-gray-600 ${reaction.hasReacted ? 'hover:bg-indigo-100 dark:hover:bg-indigo-900' : 'hover:bg-gray-100 dark:hover:bg-gray-800'}`}
                  aria-label={`${reaction.count}人のリアクションを表示`}
                >
                  {reaction.count}

--- a/components/SinglePost.tsx
+++ b/components/SinglePost.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { useState, useEffect, useRef, type FormEvent, type MouseEvent, type PointerEvent } from 'react';
-import { Heart, Trash2, BadgeCheck, Loader2, Share2, Send, User as UserIcon, AlertTriangle, CornerDownRight, X, Plus } from 'lucide-react';
+import { Heart, Trash2, BadgeCheck, Loader2, Share2, Send, User as UserIcon, AlertTriangle, CornerDownRight, X, Plus, Pencil } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { toggleLike, toggleReaction, deletePost } from '@/app/actions/post';
+import { toggleLike, toggleReaction, deletePost, updatePostComment } from '@/app/actions/post';
 import { addComment, deleteComment } from '@/app/actions/comment';
 import { RoleBadge } from '@/components/RoleBadge';
 import { ImageCarousel } from '@/components/ImageCarousel';
@@ -42,7 +42,7 @@ function toggleReactionSummary(
       current[index] = { ...existing, count: existing.count + 1, hasReacted: true };
     }
   } else {
-    current.push({ reactionKey, emoji: customEmoji ? `:${customEmoji.name}:` : reactionKeyToEmoji(reactionKey), count: 1, hasReacted: true, customEmoji });
+    current.push({ reactionKey, emoji: customEmoji ? `:${customEmoji.name}:` : reactionKeyToEmoji(reactionKey), count: 1, hasReacted: true, customEmoji, users: [] });
   }
 
   return current.sort((a, b) => b.count - a.count || a.reactionKey.localeCompare(b.reactionKey));
@@ -96,6 +96,10 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
   const [customEmojiError, setCustomEmojiError] = useState<string | null>(null);
   const [previewReaction, setPreviewReaction] = useState<PostReactionSummary | null>(null);
   const [enlargedCustomEmoji, setEnlargedCustomEmoji] = useState<CustomEmojiSummary | null>(null);
+  const [isEditingPostComment, setIsEditingPostComment] = useState(false);
+  const [editCommentText, setEditCommentText] = useState(initialPost.comment ?? '');
+  const [isSavingPostComment, setIsSavingPostComment] = useState(false);
+  const [reactionViewer, setReactionViewer] = useState<PostReactionSummary | null>(null);
   const commentInputRef = useRef<HTMLInputElement>(null);
   const reactionPreviewTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reactionPreviewDismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -120,7 +124,10 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
   const router = useRouter();
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- keep local optimistic state aligned after router.refresh() supplies a new post payload.
     setPost(initialPost);
+    setEditCommentText(initialPost.comment ?? '');
+    setIsEditingPostComment(false);
   }, [initialPost]);
 
   const isGuest = currentUserId === -1 || !currentUserId;
@@ -345,6 +352,34 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
     router.push('/');
   };
 
+  const startEditingPostComment = () => {
+    setEditCommentText(post.comment ?? '');
+    setIsEditingPostComment(true);
+  };
+
+  const cancelEditingPostComment = () => {
+    setEditCommentText(post.comment ?? '');
+    setIsEditingPostComment(false);
+  };
+
+  const handleSavePostComment = async () => {
+    if (editCommentText.trim().length > 173) {
+      alert('コメントが長すぎます(173文字まで)');
+      return;
+    }
+
+    setIsSavingPostComment(true);
+    const result = await updatePostComment(post.id, editCommentText);
+    setIsSavingPostComment(false);
+
+    if (result?.success) {
+      setPost((current) => ({ ...current, comment: result.comment }));
+      setIsEditingPostComment(false);
+    } else {
+      alert(result?.message || '投稿の編集に失敗しました');
+    }
+  };
+
   const handleShare = async () => {
       // Use the actual post URL instead of just the image API URL
       const url = `${window.location.origin}/p/${post.id}`;
@@ -519,21 +554,68 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
            </div>
 
            {currentUserId === post.userId && (
-              <button
-               onClick={handleDelete}
-               disabled={isDeleting}
-               className="text-gray-400 dark:text-gray-500 hover:text-red-500 disabled:opacity-50"
-              >
-                <Trash2 className="w-5 h-5" />
-              </button>
+              <div className="flex items-center gap-2">
+                <button
+                 type="button"
+                 onClick={startEditingPostComment}
+                 disabled={isDeleting || isSavingPostComment}
+                 className="text-gray-400 dark:text-gray-500 hover:text-indigo-500 disabled:opacity-50"
+                 aria-label="投稿本文を編集"
+                >
+                  <Pencil className="w-5 h-5" />
+                </button>
+                <button
+                 type="button"
+                 onClick={handleDelete}
+                 disabled={isDeleting}
+                 className="text-gray-400 dark:text-gray-500 hover:text-red-500 disabled:opacity-50"
+                 aria-label="投稿を削除"
+                >
+                  <Trash2 className="w-5 h-5" />
+                </button>
+              </div>
            )}
          </div>
 
-         {post.comment && (
+         {isEditingPostComment ? (
+           <div className="mb-3 rounded-lg border border-gray-200 p-3 dark:border-gray-700">
+             <textarea
+               value={editCommentText}
+               onChange={(event) => setEditCommentText(event.target.value)}
+               maxLength={173}
+               rows={4}
+               className="w-full resize-none rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+               placeholder="本文を入力"
+             />
+             <div className="mt-2 flex items-center justify-between">
+               <span className={`text-[10px] ${editCommentText.trim().length >= 173 ? 'text-red-500' : 'text-gray-400'}`}>
+                 {editCommentText.trim().length}/173
+               </span>
+               <div className="flex gap-2">
+                 <button
+                   type="button"
+                   onClick={cancelEditingPostComment}
+                   disabled={isSavingPostComment}
+                   className="rounded-full px-3 py-1 text-xs font-semibold text-gray-500 hover:bg-gray-100 disabled:opacity-50 dark:text-gray-300 dark:hover:bg-gray-800"
+                 >
+                   キャンセル
+                 </button>
+                 <button
+                   type="button"
+                   onClick={handleSavePostComment}
+                   disabled={isSavingPostComment || editCommentText.trim().length > 173}
+                   className="rounded-full bg-indigo-600 px-3 py-1 text-xs font-semibold text-white hover:bg-indigo-500 disabled:opacity-50"
+                 >
+                   {isSavingPostComment ? '保存中...' : '保存'}
+                 </button>
+               </div>
+             </div>
+           </div>
+         ) : post.comment ? (
            <p className="text-gray-900 dark:text-gray-100 break-words mb-2">
              <Linkify>{post.comment}</Linkify>
            </p>
-         )}
+         ) : null}
 
          {post.hashtags && post.hashtags.length > 0 && (
            <div className="flex flex-wrap gap-1 mb-2">
@@ -567,33 +649,44 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
          <div className="space-y-3 border-t dark:border-gray-800 pt-3">
            <div className="flex flex-wrap items-center gap-1 pb-3 border-b border-gray-100 dark:border-gray-800" data-emoji-picker="unicode-emoji-grid">
            {(post.reactions || []).map((reaction) => (
-             <button
+             <div
                key={reaction.reactionKey}
-               type="button"
-               onClick={(event) => handleReactionChipClick(event, reaction.reactionKey)}
-               onMouseEnter={() => reaction.customEmoji && handleReactionMouseEnter(reaction)}
-               onMouseLeave={reaction.customEmoji ? handleReactionMouseLeave : undefined}
-               onPointerDown={(event) => {
-                 if (reaction.customEmoji) handleReactionPointerDown(event, reaction);
-               }}
-               onPointerUp={reaction.customEmoji ? handleReactionPointerUp : undefined}
-               onPointerCancel={reaction.customEmoji ? handleReactionPointerCancel : undefined}
-               onPointerLeave={(event) => {
-                 if (event.pointerType !== 'mouse' && reaction.customEmoji) handleReactionPointerCancel();
-               }}
-               onContextMenu={(event) => {
-                 if (reaction.customEmoji) event.preventDefault();
-               }}
-               className={`select-none px-2 py-1 rounded-full border text-sm transition-colors [-webkit-touch-callout:none] ${reaction.hasReacted ? 'bg-indigo-50 border-indigo-300 text-indigo-700 dark:bg-indigo-950 dark:border-indigo-700 dark:text-indigo-200' : 'bg-gray-50 border-gray-200 dark:bg-gray-900 dark:border-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800'}`}
-               aria-label={reaction.customEmoji ? `:${reaction.customEmoji.name}: のリアクションを切り替え` : `${reaction.emoji} のリアクションを切り替え`}
+               className={`inline-flex overflow-hidden rounded-full border text-sm transition-colors ${reaction.hasReacted ? 'bg-indigo-50 border-indigo-300 text-indigo-700 dark:bg-indigo-950 dark:border-indigo-700 dark:text-indigo-200' : 'bg-gray-50 border-gray-200 dark:bg-gray-900 dark:border-gray-700 dark:text-gray-200'}`}
              >
-               {reaction.customEmoji ? (
-                 <img src={getCustomEmojiImageSrc(reaction.customEmoji)} alt={`:${reaction.customEmoji.name}:`} width={24} height={24} draggable={false} className="mr-1 inline-block h-6 w-6 select-none rounded-sm object-contain align-middle [-webkit-touch-callout:none]" />
-               ) : (
-                 <span className="mr-1">{reaction.emoji}</span>
-               )}
-               <span className="text-xs font-semibold">{reaction.count}</span>
-             </button>
+               <button
+                 type="button"
+                 onClick={(event) => handleReactionChipClick(event, reaction.reactionKey)}
+                 onMouseEnter={() => reaction.customEmoji && handleReactionMouseEnter(reaction)}
+                 onMouseLeave={reaction.customEmoji ? handleReactionMouseLeave : undefined}
+                 onPointerDown={(event) => {
+                   if (reaction.customEmoji) handleReactionPointerDown(event, reaction);
+                 }}
+                 onPointerUp={reaction.customEmoji ? handleReactionPointerUp : undefined}
+                 onPointerCancel={reaction.customEmoji ? handleReactionPointerCancel : undefined}
+                 onPointerLeave={(event) => {
+                   if (event.pointerType !== 'mouse' && reaction.customEmoji) handleReactionPointerCancel();
+                 }}
+                 onContextMenu={(event) => {
+                   if (reaction.customEmoji) event.preventDefault();
+                 }}
+                 className={`select-none py-1 pl-2 pr-1 transition-colors [-webkit-touch-callout:none] ${reaction.hasReacted ? 'hover:bg-indigo-100 dark:hover:bg-indigo-900' : 'hover:bg-gray-100 dark:hover:bg-gray-800'}`}
+                 aria-label={reaction.customEmoji ? `:${reaction.customEmoji.name}: のリアクションを切り替え` : `${reaction.emoji} のリアクションを切り替え`}
+               >
+                 {reaction.customEmoji ? (
+                   <img src={getCustomEmojiImageSrc(reaction.customEmoji)} alt={`:${reaction.customEmoji.name}:`} width={24} height={24} draggable={false} className="inline-block h-6 w-6 select-none rounded-sm object-contain align-middle [-webkit-touch-callout:none]" />
+                 ) : (
+                   <span>{reaction.emoji}</span>
+                 )}
+               </button>
+               <button
+                 type="button"
+                 onClick={() => setReactionViewer(reaction)}
+                 className={`py-1 pl-1 pr-2 text-xs font-semibold transition-colors ${reaction.hasReacted ? 'hover:bg-indigo-100 dark:hover:bg-indigo-900' : 'hover:bg-gray-100 dark:hover:bg-gray-800'}`}
+                 aria-label={`${reaction.count}人のリアクションを表示`}
+               >
+                 {reaction.count}
+               </button>
+             </div>
            ))}
            <button
              type="button"
@@ -689,6 +782,57 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
            </div>
        </div>
     </div>
+
+    {reactionViewer && (
+      <div className="fixed inset-0 z-[110] flex items-center justify-center bg-black/50 p-4" role="dialog" aria-modal="true" aria-label="リアクションしたユーザー">
+        <div className="w-full max-w-sm overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-2xl dark:border-gray-700 dark:bg-gray-900">
+          <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3 dark:border-gray-700">
+            <div className="flex items-center gap-2 text-sm font-semibold text-gray-900 dark:text-gray-100">
+              {reactionViewer.customEmoji ? (
+                <img src={getCustomEmojiImageSrc(reactionViewer.customEmoji)} alt={`:${reactionViewer.customEmoji.name}:`} width={24} height={24} className="h-6 w-6 rounded-sm object-contain" />
+              ) : (
+                <span className="text-xl">{reactionViewer.emoji}</span>
+              )}
+              <span>{reactionViewer.count}人</span>
+            </div>
+            <button
+              type="button"
+              onClick={() => setReactionViewer(null)}
+              className="rounded-full p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+              aria-label="閉じる"
+            >
+              <X className="h-5 w-5" />
+            </button>
+          </div>
+          <div className="max-h-[60vh] overflow-y-auto p-2">
+            {reactionViewer.users.map((user) => (
+              <Link
+                key={user.id}
+                href={`/users/${user.username}`}
+                onClick={() => setReactionViewer(null)}
+                className="flex items-center gap-3 rounded-xl px-3 py-2 hover:bg-gray-100 dark:hover:bg-gray-800"
+              >
+                <div className="h-9 w-9 flex-shrink-0 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
+                  {user.avatarUrl ? (
+                    <img src={user.avatarUrl} alt={user.username} className="h-full w-full object-cover" />
+                  ) : (
+                    <div className="flex h-full w-full items-center justify-center text-gray-500 dark:text-gray-300">
+                      <UserIcon className="h-5 w-5" />
+                    </div>
+                  )}
+                </div>
+                <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">@{user.username}</span>
+              </Link>
+            ))}
+            {reactionViewer.users.length < reactionViewer.count && (
+              <p className="px-3 py-2 text-xs text-gray-500 dark:text-gray-400">
+                ほか{reactionViewer.count - reactionViewer.users.length}人
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+    )}
 
     {previewReaction?.customEmoji && (
       <div className="pointer-events-none fixed inset-0 z-[90] flex items-center justify-center p-4" aria-hidden="true">

--- a/components/SinglePost.tsx
+++ b/components/SinglePost.tsx
@@ -490,8 +490,8 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
        )}
 
        <div className="p-4">
-         <div className="flex items-center justify-between mb-4">
-           <div className="flex items-center gap-3">
+         <div className="mb-4 flex flex-wrap items-center justify-between gap-x-3 gap-y-2">
+           <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-3 gap-y-2">
                <button
                    onClick={handleLike}
                    className="flex items-center gap-1.5 transition-colors group"
@@ -520,8 +520,8 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
 
                {/* User Info */}
                {post.user && (
-                   <div className="flex items-center gap-2 ml-2">
-                        <div className="w-6 h-6 rounded-full bg-gray-200 dark:bg-gray-700 overflow-hidden flex-shrink-0">
+                   <div className="ml-0 flex min-w-0 flex-wrap items-center gap-2 sm:ml-2">
+                        <div className="h-6 w-6 flex-shrink-0 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
                            {post.user.avatarUrl ? (
                                // eslint-disable-next-line @next/next/no-img-element
                                <img
@@ -536,7 +536,7 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
                                </div>
                            )}
                         </div>
-                        <Link href={`/users/${post.user.username}`} className="text-sm font-semibold hover:underline">
+                        <Link href={`/users/${post.user.username}`} className="min-w-0 max-w-[10rem] truncate text-sm font-semibold hover:underline sm:max-w-none">
                            @{post.user.username}
                         </Link>
                         {post.user.isGold ? (
@@ -545,7 +545,7 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
                           <BadgeCheck className="w-4 h-4 text-blue-500" />
                         ) : null}
                         {post.user.roles?.map(roleId => (
-                           <div key={roleId} className="scale-75 origin-left flex item-center">
+                           <div key={roleId} className="flex origin-left scale-75 items-center">
                                <RoleBadge roleId={roleId} />
                            </div>
                         ))}
@@ -554,7 +554,7 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
            </div>
 
            {currentUserId === post.userId && (
-              <div className="flex items-center gap-2">
+              <div className="ml-auto flex shrink-0 items-center gap-2">
                 <button
                  type="button"
                  onClick={startEditingPostComment}

--- a/lib/reactions.ts
+++ b/lib/reactions.ts
@@ -2,7 +2,7 @@ export type ReactionUserSummary = {
   id: number;
   username: string;
   avatarUrl: string | null;
-  updatedAt?: Date;
+  updatedAt?: Date | string;
 };
 
 export type PostReactionSummary = {
@@ -133,13 +133,20 @@ export function reactionKeyToEmoji(reactionKey: string): string {
   return reactionKey;
 }
 
+function getAvatarCacheVersion(updatedAt: Date | string | undefined): string {
+  if (!updatedAt) return '';
+  const timestamp = updatedAt instanceof Date
+    ? updatedAt.getTime()
+    : new Date(updatedAt).getTime();
+
+  return Number.isNaN(timestamp) ? '' : `?v=${timestamp}`;
+}
+
 function normalizeReactionUser(user: ReactionUserSummary): ReactionUserSummary {
   return {
     ...user,
     avatarUrl: user.avatarUrl
-      ? (user.avatarUrl.startsWith('http')
-          ? user.avatarUrl
-          : `/api/avatar/${user.username}${user.updatedAt ? `?v=${user.updatedAt.getTime()}` : ''}`)
+      ? `/api/avatar/${user.username}${getAvatarCacheVersion(user.updatedAt)}`
       : null,
   };
 }

--- a/lib/reactions.ts
+++ b/lib/reactions.ts
@@ -1,9 +1,17 @@
+export type ReactionUserSummary = {
+  id: number;
+  username: string;
+  avatarUrl: string | null;
+  updatedAt?: Date;
+};
+
 export type PostReactionSummary = {
   reactionKey: string;
   emoji: string;
   count: number;
   hasReacted: boolean;
   customEmoji?: CustomEmojiSummary;
+  users: ReactionUserSummary[];
 };
 
 export type CustomEmojiSummary = {
@@ -20,6 +28,7 @@ type RawPostReaction = {
   reactionKey: string;
   userId: number;
   customEmoji?: CustomEmojiSummary | null;
+  user?: ReactionUserSummary | null;
 };
 
 const UNICODE_REACTION_PREFIX = "unicode:";
@@ -124,6 +133,17 @@ export function reactionKeyToEmoji(reactionKey: string): string {
   return reactionKey;
 }
 
+function normalizeReactionUser(user: ReactionUserSummary): ReactionUserSummary {
+  return {
+    ...user,
+    avatarUrl: user.avatarUrl
+      ? (user.avatarUrl.startsWith('http')
+          ? user.avatarUrl
+          : `/api/avatar/${user.username}${user.updatedAt ? `?v=${user.updatedAt.getTime()}` : ''}`)
+      : null,
+  };
+}
+
 export function buildPostReactionSummaries(
   reactions: RawPostReaction[],
   currentUserId: number
@@ -132,9 +152,13 @@ export function buildPostReactionSummaries(
 
   for (const reaction of reactions) {
     const existing = summaries.get(reaction.reactionKey);
+    const user = reaction.user ? normalizeReactionUser(reaction.user) : null;
     if (existing) {
       existing.count += 1;
       existing.hasReacted ||= reaction.userId === currentUserId;
+      if (user && !existing.users.some((existingUser) => existingUser.id === user.id)) {
+        existing.users.push(user);
+      }
     } else {
       summaries.set(reaction.reactionKey, {
         reactionKey: reaction.reactionKey,
@@ -142,6 +166,7 @@ export function buildPostReactionSummaries(
         count: 1,
         hasReacted: reaction.userId === currentUserId,
         customEmoji: reaction.customEmoji ?? undefined,
+        users: user ? [user] : [],
       });
     }
   }


### PR DESCRIPTION
## Summary
- 投稿本文を投稿者が編集できるようにしました
- リアクション数からリアクションしたユーザー一覧を見られるようにしました
- カスタム絵文字の長押し/ホバー拡大挙動を維持しました
- モバイル幅で投稿アクション行が画面外へはみ出さないように折り返し対応しました

## Verification
- `npx tsc --noEmit`
- `npx eslint components/Feed.tsx components/SinglePost.tsx app/actions/post.ts lib/reactions.ts app/profile/page.tsx app/users/[username]/page.tsx app/p/[id]/page.tsx`
- `git diff --check`

## Notes
- `npm run build` はローカル環境で `SESSION_SECRET` が未設定のためページデータ収集で失敗します。コンパイルと TypeScript フェーズは通過しています。
- `SUPABASE_SERVICE_KEY` 未設定の警告もローカル環境由来です。
