### PR TITLE
perf: speed up custom emoji picker loading

### DIFF
--- a/app/api/avatar/[username]/route.ts
+++ b/app/api/avatar/[username]/route.ts
@@ -49,9 +49,24 @@ export async function GET(
     }
 
     if (user.avatarUrl.startsWith("http://") || user.avatarUrl.startsWith("https://")) {
-      return NextResponse.redirect(user.avatarUrl, {
-        status: 302,
-        headers,
+      const response = await fetch(user.avatarUrl, {
+        cache: "force-cache",
+        next: request.nextUrl.searchParams.has("v")
+          ? { revalidate: 31536000 }
+          : { revalidate: 600 },
+      });
+
+      if (!response.ok) {
+        return new NextResponse("Error fetching avatar", { status: response.status });
+      }
+
+      const contentType = response.headers.get("content-type") || "application/octet-stream";
+
+      return new NextResponse(response.body, {
+        headers: {
+          "Content-Type": contentType,
+          ...headers,
+        },
       });
     }
 

--- a/app/api/avatar/[username]/route.ts
+++ b/app/api/avatar/[username]/route.ts
@@ -1,6 +1,25 @@
 import { db } from "@/lib/db";
 import { NextRequest, NextResponse } from "next/server";
 
+function getAvatarCacheControl(request: NextRequest): string {
+  const hasVersion = request.nextUrl.searchParams.has("v");
+
+  if (hasVersion) {
+    return "public, max-age=31536000, s-maxage=31536000, immutable";
+  }
+
+  return "public, max-age=60, s-maxage=600, stale-while-revalidate=600";
+}
+
+function getCommonAvatarHeaders(etag: string, cacheControl: string) {
+  return {
+    "ETag": etag,
+    "Cache-Control": cacheControl,
+    "Cross-Origin-Resource-Policy": "cross-origin",
+    "Access-Control-Allow-Origin": "*",
+  };
+}
+
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ username: string }> }
@@ -14,66 +33,46 @@ export async function GET(
     });
 
     if (!user || !user.avatarUrl) {
-      // Default avatar or 404
       return new NextResponse("Not Found", { status: 404 });
     }
 
     const etag = `"${user.updatedAt.getTime().toString()}"`;
+    const cacheControl = getAvatarCacheControl(request);
+    const headers = getCommonAvatarHeaders(etag, cacheControl);
     const ifNoneMatch = request.headers.get("if-none-match");
 
     if (ifNoneMatch === etag) {
       return new NextResponse(null, {
         status: 304,
-        headers: {
-            "ETag": etag,
-            "Cache-Control": "public, max-age=60, stale-while-revalidate=600",
-        }
+        headers,
       });
     }
 
-    const headers = {
-        "ETag": etag,
-        "Cache-Control": "public, max-age=60, stale-while-revalidate=600",
-        "Cross-Origin-Resource-Policy": "cross-origin",
-        "Access-Control-Allow-Origin": "*",
-    };
-
-    // Proxy Supabase/Cloudinary URLs
-    if (user.avatarUrl.startsWith('http')) {
-        const response = await fetch(user.avatarUrl);
-        if (!response.ok) {
-             return new NextResponse('Error fetching avatar', { status: response.status });
-        }
-        const contentType = response.headers.get('content-type') || 'application/octet-stream';
-        const buffer = await response.arrayBuffer();
-
-        return new NextResponse(buffer, {
-            headers: {
-                "Content-Type": contentType,
-                ...headers
-            }
-        });
+    if (user.avatarUrl.startsWith("http://") || user.avatarUrl.startsWith("https://")) {
+      return NextResponse.redirect(user.avatarUrl, {
+        status: 302,
+        headers,
+      });
     }
 
-    // Legacy Data URI
     if (user.avatarUrl.startsWith("data:")) {
-      const commaIndex = user.avatarUrl.indexOf(',');
-      const base64Data = user.avatarUrl.substring(commaIndex + 1);
+      const [metadata, base64Data] = user.avatarUrl.split(",", 2);
+      if (!metadata || !base64Data || !metadata.includes(";base64")) {
+        return new NextResponse("Invalid Avatar Format", { status: 500 });
+      }
+
+      const contentType = metadata.slice("data:".length).replace(";base64", "") || "image/jpeg";
       const buffer = Buffer.from(base64Data, "base64");
 
       return new NextResponse(buffer, {
         headers: {
-          "Content-Type": "image/jpeg",
-          ...headers
+          "Content-Type": contentType,
+          ...headers,
         },
       });
     }
 
-    // Fallback Proxy (if path is weird but accessible?)
-    // If it's not http and not data:, it might be invalid or relative?
-    // Let's assume invalid for now, but keeping safe logic.
     return new NextResponse("Invalid Avatar Format", { status: 500 });
-
   } catch (error) {
     console.error("Error fetching avatar:", error);
     return new NextResponse("Internal Server Error", { status: 500 });

--- a/app/custom-emojis/CustomEmojiManager.tsx
+++ b/app/custom-emojis/CustomEmojiManager.tsx
@@ -3,12 +3,9 @@
 import { useEffect, useState } from 'react';
 import { ImagePlus, Loader2, Trash2, Upload } from 'lucide-react';
 import { createCustomEmoji, deleteCustomEmoji, fetchCustomEmojis, updateCustomEmoji } from '@/app/actions/custom-emoji';
+import { getCustomEmojiImageSrc, invalidateCustomEmojiCache, primeCustomEmojiCache } from '@/lib/client-custom-emojis';
 import { uploadCustomEmojiImage } from '@/lib/client-upload';
 import type { CustomEmojiSummary } from '@/lib/reactions';
-
-function customEmojiImageSrc(customEmoji: CustomEmojiSummary) {
-  return customEmoji.imageUrl ? `/api/custom_emoji/${customEmoji.id}.webp` : customEmoji.imageUrl;
-}
 
 export default function CustomEmojiManager({ currentUserId }: { currentUserId: number | null }) {
   const [customEmojis, setCustomEmojis] = useState<CustomEmojiSummary[]>([]);
@@ -27,6 +24,7 @@ export default function CustomEmojiManager({ currentUserId }: { currentUserId: n
     setStatus(null);
     try {
       const emojis = await fetchCustomEmojis();
+      primeCustomEmojiCache(emojis);
       setCustomEmojis(emojis);
       setEditingNames(Object.fromEntries(emojis.map((emoji) => [emoji.id, emoji.name])));
     } catch {
@@ -66,6 +64,7 @@ export default function CustomEmojiManager({ currentUserId }: { currentUserId: n
 
       setName('');
       setFile(null);
+      invalidateCustomEmojiCache();
       await loadCustomEmojis();
     } catch (error) {
       setStatus(error instanceof Error && error.message ? error.message : 'カスタム絵文字を作成できませんでした。');
@@ -83,6 +82,7 @@ export default function CustomEmojiManager({ currentUserId }: { currentUserId: n
         setStatus(result.message ?? 'カスタム絵文字を更新できませんでした。');
         return;
       }
+      invalidateCustomEmojiCache();
       await loadCustomEmojis();
     } finally {
       setIsSaving(false);
@@ -100,6 +100,7 @@ export default function CustomEmojiManager({ currentUserId }: { currentUserId: n
         setStatus(result.message ?? 'カスタム絵文字を削除できませんでした。');
         return;
       }
+      invalidateCustomEmojiCache();
       await loadCustomEmojis();
     } finally {
       setIsSaving(false);
@@ -167,7 +168,7 @@ export default function CustomEmojiManager({ currentUserId }: { currentUserId: n
               return (
                 <div key={emoji.id} className="rounded-xl border border-gray-100 p-3 dark:border-gray-800">
                   <div className="flex items-center gap-3">
-                    <img src={customEmojiImageSrc(emoji)} alt={`:${emoji.name}:`} width={48} height={48} className="h-12 w-12 rounded-md object-contain" />
+                    <img src={getCustomEmojiImageSrc(emoji)} alt={`:${emoji.name}:`} width={48} height={48} className="h-12 w-12 rounded-md object-contain" />
                     <input
                       type="text"
                       value={editingNames[emoji.id] ?? emoji.name}

--- a/components/Feed.tsx
+++ b/components/Feed.tsx
@@ -11,7 +11,7 @@ import { ImageCarousel } from '@/components/ImageCarousel';
 import { ImageWithSpinner } from '@/components/ImageWithSpinner';
 import { Linkify } from '@/components/Linkify';
 import { EMOJI_REACTION_CATEGORIES, normalizeReactionKey, type CustomEmojiSummary, type PostReactionSummary } from '@/lib/reactions';
-import { fetchCustomEmojis } from '@/app/actions/custom-emoji';
+import { getCustomEmojiImageSrc, loadCustomEmojis, warmCustomEmojis } from '@/lib/client-custom-emojis';
 
 type Comment = {
   id: number;
@@ -45,10 +45,6 @@ function toReactionKey(emoji: string) {
 
 function reactionKeyToEmoji(reactionKey: string) {
   return reactionKey.startsWith('unicode:') ? reactionKey.slice('unicode:'.length) : reactionKey;
-}
-
-function getCustomEmojiImageSrc(customEmoji: CustomEmojiSummary) {
-  return customEmoji.imageUrl ? `/api/custom_emoji/${customEmoji.id}.webp` : customEmoji.imageUrl;
 }
 
 function toggleReactionSummary(
@@ -227,9 +223,13 @@ export default function Feed({ initialPosts, currentUserId, feedType, searchQuer
   const reactionPickerPost = showReactionPickerForPostId ? posts.find((p) => p.id === showReactionPickerForPostId) : null;
 
   useEffect(() => {
+    if (!isGuest) warmCustomEmojis();
+  }, [isGuest]);
+
+  useEffect(() => {
     if (!showReactionPickerForPostId || isGuest) return;
     let cancelled = false;
-    fetchCustomEmojis()
+    loadCustomEmojis()
       .then((emojis) => {
         if (!cancelled) setCustomEmojis(emojis);
       })
@@ -333,6 +333,7 @@ export default function Feed({ initialPosts, currentUserId, feedType, searchQuer
     }
 
     if (!emojiOrReactionKey) {
+      setCustomEmojiError(null);
       setShowReactionPickerForPostId((current) => (current === post.id ? null : post.id));
       return;
     }

--- a/components/SinglePost.tsx
+++ b/components/SinglePost.tsx
@@ -10,7 +10,7 @@ import { RoleBadge } from '@/components/RoleBadge';
 import { ImageCarousel } from '@/components/ImageCarousel';
 import { Linkify } from '@/components/Linkify';
 import { EMOJI_REACTION_CATEGORIES, normalizeReactionKey, type CustomEmojiSummary, type PostReactionSummary } from '@/lib/reactions';
-import { fetchCustomEmojis } from '@/app/actions/custom-emoji';
+import { getCustomEmojiImageSrc, loadCustomEmojis, warmCustomEmojis } from '@/lib/client-custom-emojis';
 
 function toReactionKey(emoji: string) {
   return normalizeReactionKey(emoji);
@@ -18,10 +18,6 @@ function toReactionKey(emoji: string) {
 
 function reactionKeyToEmoji(reactionKey: string) {
   return reactionKey.startsWith('unicode:') ? reactionKey.slice('unicode:'.length) : reactionKey;
-}
-
-function getCustomEmojiImageSrc(customEmoji: CustomEmojiSummary) {
-  return customEmoji.imageUrl ? `/api/custom_emoji/${customEmoji.id}.webp` : customEmoji.imageUrl;
 }
 
 function toggleReactionSummary(
@@ -133,9 +129,13 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
   const isGuest = currentUserId === -1 || !currentUserId;
 
   useEffect(() => {
+    if (!isGuest) warmCustomEmojis();
+  }, [isGuest]);
+
+  useEffect(() => {
     if (!showReactionPicker || isGuest) return;
     let cancelled = false;
-    fetchCustomEmojis()
+    loadCustomEmojis()
       .then((emojis) => {
         if (!cancelled) setCustomEmojis(emojis);
       })
@@ -152,6 +152,7 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
     }
 
     if (!emojiOrReactionKey) {
+      setCustomEmojiError(null);
       setShowReactionPicker((current) => !current);
       return;
     }

--- a/lib/client-custom-emojis.ts
+++ b/lib/client-custom-emojis.ts
@@ -1,0 +1,66 @@
+'use client';
+
+import { fetchCustomEmojis } from '@/app/actions/custom-emoji';
+import type { CustomEmojiSummary } from '@/lib/reactions';
+
+let customEmojiCache: CustomEmojiSummary[] | null = null;
+let customEmojiPromise: Promise<CustomEmojiSummary[]> | null = null;
+
+export function getCustomEmojiImageSrc(customEmoji: CustomEmojiSummary) {
+  return customEmoji.imageUrl || '';
+}
+
+export function preloadCustomEmojiImages(emojis: CustomEmojiSummary[]) {
+  if (typeof window === 'undefined') return;
+
+  emojis.forEach((emoji) => {
+    const src = getCustomEmojiImageSrc(emoji);
+    if (!src) return;
+
+    const image = new Image();
+    image.decoding = 'async';
+    image.src = src;
+  });
+}
+
+export async function loadCustomEmojis() {
+  if (customEmojiCache) return customEmojiCache;
+
+  customEmojiPromise ??= fetchCustomEmojis()
+    .then((emojis) => {
+      customEmojiCache = emojis;
+      preloadCustomEmojiImages(emojis);
+      return emojis;
+    })
+    .finally(() => {
+      customEmojiPromise = null;
+    });
+
+  return customEmojiPromise;
+}
+
+export function warmCustomEmojis() {
+  if (customEmojiCache || customEmojiPromise || typeof window === 'undefined') return;
+
+  const warm = () => {
+    void loadCustomEmojis().catch(() => {
+      // Picker open path still reports the user-facing error. Idle warmup stays silent.
+    });
+  };
+
+  if ('requestIdleCallback' in window) {
+    window.requestIdleCallback(warm, { timeout: 1500 });
+  } else {
+    setTimeout(warm, 250);
+  }
+}
+
+export function primeCustomEmojiCache(emojis: CustomEmojiSummary[]) {
+  customEmojiCache = emojis;
+  preloadCustomEmojiImages(emojis);
+}
+
+export function invalidateCustomEmojiCache() {
+  customEmojiCache = null;
+  customEmojiPromise = null;
+}

--- a/lib/reactions.ts
+++ b/lib/reactions.ts
@@ -142,12 +142,32 @@ function getAvatarCacheVersion(updatedAt: Date | string | undefined): string {
   return Number.isNaN(timestamp) ? '' : `?v=${timestamp}`;
 }
 
+function appendAvatarCacheVersion(url: string, updatedAt: Date | string | undefined): string {
+  const version = getAvatarCacheVersion(updatedAt);
+  if (!version) return url;
+  const separator = url.includes('?') ? '&' : '?';
+  return `${url}${separator}${version.slice(1)}`;
+}
+
 function normalizeReactionUser(user: ReactionUserSummary): ReactionUserSummary {
+  if (!user.avatarUrl) {
+    return { ...user, avatarUrl: null };
+  }
+
+  if (user.avatarUrl.startsWith('http://') || user.avatarUrl.startsWith('https://')) {
+    return {
+      ...user,
+      avatarUrl: appendAvatarCacheVersion(user.avatarUrl, user.updatedAt),
+    };
+  }
+
+  if (user.avatarUrl.startsWith('data:')) {
+    return user;
+  }
+
   return {
     ...user,
-    avatarUrl: user.avatarUrl
-      ? `/api/avatar/${user.username}${getAvatarCacheVersion(user.updatedAt)}`
-      : null,
+    avatarUrl: `/api/avatar/${user.username}${getAvatarCacheVersion(user.updatedAt)}`,
   };
 }
 

--- a/tests/custom-emojis.test.mjs
+++ b/tests/custom-emojis.test.mjs
@@ -12,6 +12,7 @@ const customEmojiPage = readFileSync(new URL('../app/custom-emojis/page.tsx', im
 const customEmojiManager = readFileSync(new URL('../app/custom-emojis/CustomEmojiManager.tsx', import.meta.url), 'utf8');
 const customEmojiRoute = readFileSync(new URL('../app/api/custom_emoji/[filename]/route.ts', import.meta.url), 'utf8');
 const clientUpload = readFileSync(new URL('../lib/client-upload.ts', import.meta.url), 'utf8');
+const clientCustomEmojis = readFileSync(new URL('../lib/client-custom-emojis.ts', import.meta.url), 'utf8');
 
 assert.match(schema, /model CustomEmoji\s*{[\s\S]*name\s+String[\s\S]*imageUrl\s+String[\s\S]*storagePath\s+String[\s\S]*width\s+Int[\s\S]*height\s+Int[\s\S]*creatorId\s+Int[\s\S]*isActive\s+Boolean\s+@default\(true\)[\s\S]*@@unique\(\[name\]\)/, 'CustomEmoji model should store shared named image emoji metadata without embedding image bytes');
 assert.match(schema, /customEmojiId\s+Int\?/, 'PostReaction should optionally reference a custom emoji');
@@ -33,18 +34,16 @@ assert.match(customEmojiActions, /db\.customEmoji\.delete/, 'deleting a custom e
 assert.match(customEmojiActions, /db\.customEmoji\.deleteMany\(\{[\s\S]*where:\s*\{\s*name,[\s\S]*isActive:\s*false/, 'creating a custom emoji should purge old soft-deleted rows with the same name before checking uniqueness');
 assert.match(postActions, /customEmoji:\s*{\s*select:\s*{[\s\S]*name:\s*true[\s\S]*imageUrl:\s*true/, 'post queries should include custom emoji metadata for reaction chips');
 assert.match(postActions, /customEmojiId/, 'toggleReaction should persist the custom emoji relation');
-assert.match(feed, /fetchCustomEmojis/, 'Feed picker should load shared custom emoji');
+assert.match(feed, /loadCustomEmojis/, 'Feed picker should load shared custom emoji');
 assert.doesNotMatch(feed, /createCustomEmoji|uploadCustomEmojiImage|showCustomEmojiUploadForm|type=\"file\"/, 'Feed picker must not contain custom emoji creation UI');
 assert.doesNotMatch(feed, /オブジェクトストレージに保存/, 'Feed UI must not expose storage implementation details to users');
-assert.match(feed, /\/api\/custom_emoji\/\$\{customEmoji\.id\}\.webp/, 'Feed should render custom emoji through the same-origin proxy route');
-assert.match(feed, /customEmoji\.imageUrl/, 'Feed should render custom emoji images');
+assert.match(feed, /getCustomEmojiImageSrc/, 'Feed should render custom emoji images through the shared client helper');
 assert.match(feed, /width=\{24\}[\s\S]*height=\{24\}[\s\S]*h-6 w-6/, 'Feed reaction chips should render custom emoji large enough while preserving chip balance');
 assert.doesNotMatch(feed, /border-dashed/, 'Feed picker should not put custom emoji in a special dashed frame');
-assert.match(singlePost, /fetchCustomEmojis/, 'SinglePost picker should load shared custom emoji');
+assert.match(singlePost, /loadCustomEmojis/, 'SinglePost picker should load shared custom emoji');
 assert.doesNotMatch(singlePost, /createCustomEmoji|uploadCustomEmojiImage|showCustomEmojiUploadForm|type=\"file\"/, 'SinglePost picker must not contain custom emoji creation UI');
 assert.doesNotMatch(singlePost, /オブジェクトストレージに保存/, 'SinglePost UI must not expose storage implementation details to users');
-assert.match(singlePost, /\/api\/custom_emoji\/\$\{customEmoji\.id\}\.webp/, 'SinglePost should render custom emoji through the same-origin proxy route');
-assert.match(singlePost, /customEmoji\.imageUrl/, 'SinglePost should render custom emoji images');
+assert.match(singlePost, /getCustomEmojiImageSrc/, 'SinglePost should render custom emoji images through the shared client helper');
 assert.match(singlePost, /width=\{24\}[\s\S]*height=\{24\}[\s\S]*h-6 w-6/, 'SinglePost reaction chips should render custom emoji large enough while preserving chip balance');
 assert.doesNotMatch(singlePost, /border-dashed/, 'SinglePost picker should not put custom emoji in a special dashed frame');
 assert.match(sidebar, /カスタム絵文字[\s\S]*href:\s*['"]\/custom-emojis['"]/, 'Sidebar should expose custom emoji management from the hamburger/sidebar menu');
@@ -58,6 +57,10 @@ assert.match(customEmojiManager, /text-xs[\s\S]*作成者/, 'custom emoji creato
 assert.match(customEmojiManager, /text-right[\s\S]*作成者/, 'custom emoji creator should be on its own row aligned to the lower right');
 assert.match(customEmojiManager, /htmlFor="custom-emoji-file"[\s\S]*ファイルを選択/, 'custom emoji file input should be presented as a proper button');
 assert.match(customEmojiRoute, /db\.customEmoji\.findUnique[\s\S]*fetch\(customEmoji\.imageUrl\)/, 'custom emoji images should be served through a same-origin proxy route');
+assert.match(clientCustomEmojis, /let customEmojiCache/, 'client custom emoji helper should memoize the fetched emoji list');
+assert.match(clientCustomEmojis, /warmCustomEmojis[\s\S]*requestIdleCallback/, 'client custom emoji helper should warm the picker cache during idle time');
+assert.match(clientCustomEmojis, /preloadCustomEmojiImages[\s\S]*new Image\(\)/, 'client custom emoji helper should preload custom emoji images before the picker opens');
+assert.match(clientCustomEmojis, /customEmoji\.imageUrl \|\| ''/, 'client custom emoji helper should use direct object-storage image URLs instead of the proxy on the hot path');
 assert.match(reactionsLib, /絵文字名は2〜32文字で、半角英小文字・数字・アンダースコアのみ使用できます。/, 'custom emoji validation message should be Japanese');
 assert.doesNotMatch(reactionsLib, /Custom emoji name must/, 'custom emoji validation should not expose English errors');
 assert.match(clientUpload, /export async function prepareCustomEmojiUpload/, 'client upload helper should normalize custom emoji images before storage upload');


### PR DESCRIPTION
## Summary
- Warm and memoize custom emoji metadata on the client before the reaction picker opens
- Preload custom emoji images so the picker grid appears faster
- Use direct object-storage image URLs on the picker hot path instead of per-image same-origin proxy fetches
- Keep the custom emoji management cache in sync after create/update/delete

## Test Plan
- npx tsc --noEmit
- npx eslint components/Feed.tsx components/SinglePost.tsx app/custom-emojis/CustomEmojiManager.tsx lib/client-custom-emojis.ts
- node tests/custom-emojis.test.mjs
