### PR TITLE
Add custom cropping and switch to draggable corner UI

### DIFF
--- a/app/contests/[id]/upload/page.tsx
+++ b/app/contests/[id]/upload/page.tsx
@@ -2,8 +2,9 @@
 
 import { useActionState, useState, useRef, useCallback, useEffect } from "react";
 import { createContestPost } from "@/app/actions/contest";
-import { Camera, Check, X, Smartphone, Image as ImageIcon } from "lucide-react";
-import Cropper from "react-easy-crop";
+import { Camera, Check, X, Smartphone, Image as ImageIcon, Maximize } from "lucide-react";
+import ReactCrop, { centerCrop, makeAspectCrop, Crop, PixelCrop, convertToPixelCrop } from 'react-image-crop';
+import 'react-image-crop/dist/ReactCrop.css';
 import { getCroppedImg } from "@/lib/image";
 import { ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
@@ -12,7 +13,7 @@ import { uploadImageToSupabase } from "@/lib/client-upload";
 import { Spinner } from "@/components/ui/spinner";
 
 type Area = { x: number; y: number; width: number; height: number };
-type AspectRatio = "1:1" | "original";
+type AspectRatio = "1:1" | "original" | "custom";
 
 import { use } from "react";
 
@@ -28,20 +29,61 @@ export default function ContestUploadPage({ params }: { params: Promise<{ id: st
   }, [state, contestId, router]);
 
   const [imageSrc, setImageSrc] = useState<string | null>(null);
-  const [crop, setCrop] = useState({ x: 0, y: 0 });
-  const [zoom, setZoom] = useState(1);
-  const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | null>(null);
+  const [crop, setCrop] = useState<Crop>();
+  const [completedCrop, setCompletedCrop] = useState<PixelCrop>();
   const [croppedImages, setCroppedImages] = useState<string[]>([]);
   const [comment, setComment] = useState("");
   const [aspectRatio, setAspectRatio] = useState<AspectRatio>("1:1");
   const [imageAspectRatio, setImageAspectRatio] = useState<number>(1);
   const [isUploading, setIsUploading] = useState(false);
+  const imgRef = useRef<HTMLImageElement>(null);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const onCropComplete = useCallback((croppedArea: Area, croppedAreaPixels: Area) => {
-    setCroppedAreaPixels(croppedAreaPixels);
-  }, []);
+  function onImageLoad(e: React.SyntheticEvent<HTMLImageElement>) {
+    const { width, height } = e.currentTarget;
+    const aspect = width / height;
+    setImageAspectRatio(aspect);
+
+    const initialAspect = aspectRatio === "1:1" ? 1 : aspectRatio === "original" ? aspect : undefined;
+
+    const newCrop = centerCrop(
+      makeAspectCrop(
+        {
+          unit: '%',
+          width: 90,
+        },
+        initialAspect,
+        width,
+        height,
+      ),
+      width,
+      height,
+    );
+    setCrop(newCrop);
+  }
+
+  useEffect(() => {
+    if (imageSrc && imgRef.current) {
+        const { width, height } = imgRef.current;
+        const aspect = aspectRatio === "1:1" ? 1 : aspectRatio === "original" ? imageAspectRatio : undefined;
+
+        const newCrop = centerCrop(
+          makeAspectCrop(
+            {
+              unit: '%',
+              width: 90,
+            },
+            aspect,
+            width,
+            height,
+          ),
+          width,
+          height,
+        );
+        setCrop(newCrop);
+    }
+  }, [aspectRatio, imageAspectRatio, imageSrc]);
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -50,51 +92,62 @@ export default function ContestUploadPage({ params }: { params: Promise<{ id: st
     const reader = new FileReader();
     reader.addEventListener("load", () => {
       setImageSrc(reader.result as string);
-      const img = new Image();
-      img.onload = () => setImageAspectRatio(img.width / img.height);
-      img.src = reader.result as string;
     });
     reader.readAsDataURL(file);
     e.target.value = "";
   };
 
   const handleCropConfirm = useCallback(async () => {
-    if (!imageSrc || !croppedAreaPixels) return;
+    if (!imageSrc || !imgRef.current) return;
+
+    const image = imgRef.current;
+    let finalCrop = completedCrop;
+
+    if (!finalCrop && crop) {
+        finalCrop = convertToPixelCrop(crop, image.width, image.height);
+    }
+
+    if (!finalCrop) return;
+
+    const scaleX = image.naturalWidth / image.width;
+    const scaleY = image.naturalHeight / image.height;
+
+    const pixelCrop = {
+        x: finalCrop.x * scaleX,
+        y: finalCrop.y * scaleY,
+        width: finalCrop.width * scaleX,
+        height: finalCrop.height * scaleY,
+    };
+
     try {
       let outputWidth = 512;
       let outputHeight = 512;
 
-      if (aspectRatio === "original") {
-        const width = croppedAreaPixels.width;
-        const height = croppedAreaPixels.height;
-        const aspect = width / height;
+      const aspect = pixelCrop.width / pixelCrop.height;
 
-        if (width > height) {
+      if (aspect > 1) {
           outputWidth = 512;
           outputHeight = Math.round(512 / aspect);
-        } else {
+      } else {
           outputHeight = 512;
           outputWidth = Math.round(512 * aspect);
-        }
       }
 
       const cropped = await getCroppedImg(
         imageSrc,
-        croppedAreaPixels,
+        pixelCrop,
         { width: outputWidth, height: outputHeight }
       );
 
       if (cropped) setCroppedImages(prev => [...prev, cropped]);
       setImageSrc(null);
-      setZoom(1);
     } catch (e) {
       console.error(e);
     }
-  }, [imageSrc, croppedAreaPixels, aspectRatio]);
+  }, [imageSrc, completedCrop, crop]);
 
   const cancelCrop = () => {
     setImageSrc(null);
-    setZoom(1);
   };
 
   const removeImage = (index: number) => {
@@ -128,25 +181,38 @@ export default function ContestUploadPage({ params }: { params: Promise<{ id: st
 
   if (imageSrc) {
     return (
-      <div className="flex flex-col h-screen bg-black">
-        <div className="p-4 bg-white border-b flex flex-col gap-4 z-10">
+      <div className="flex flex-col h-screen bg-black overflow-hidden">
+        <div className="p-4 bg-white border-b flex flex-col gap-4 z-10 shrink-0">
           <div className="flex items-center justify-between gap-4">
-            <div className="flex-1">
-              <label className="text-xs text-gray-500 mb-1 block">ズーム</label>
-              <input type="range" value={zoom} min={1} max={3} step={0.1} onChange={(e) => setZoom(Number(e.target.value))} className="w-full" />
-            </div>
+            <h3 className="font-bold text-sm">範囲を選択</h3>
             <div className="flex items-center gap-2">
-              <button onClick={cancelCrop} className="p-2"><X className="w-6 h-6" /></button>
-              <button onClick={handleCropConfirm} className="px-4 py-2 bg-indigo-600 text-white rounded-md"><Check className="w-5 h-5" /></button>
+              <button onClick={cancelCrop} className="p-2 text-gray-500 hover:text-black"><X className="w-6 h-6" /></button>
+              <button onClick={handleCropConfirm} className="px-4 py-2 bg-indigo-600 text-white rounded-md font-semibold text-sm hover:bg-indigo-500"><Check className="w-5 h-5" /></button>
             </div>
           </div>
-          <div className="flex justify-center gap-4">
-            <button type="button" onClick={() => setAspectRatio("1:1")} className={`px-3 py-1.5 rounded-full text-xs font-medium flex items-center gap-1 border ${aspectRatio === "1:1" ? "bg-black text-white" : "bg-white text-gray-700"}`}><Smartphone className="w-3 h-3" /> 正方形</button>
-            <button type="button" onClick={() => setAspectRatio("original")} className={`px-3 py-1.5 rounded-full text-xs font-medium flex items-center gap-1 border ${aspectRatio === "original" ? "bg-black text-white" : "bg-white text-gray-700"}`}><ImageIcon className="w-3 h-3" /> 元の比率</button>
+          <div className="flex justify-center gap-2">
+            <button type="button" onClick={() => setAspectRatio("1:1")} className={`px-3 py-1.5 rounded-full text-xs font-medium flex items-center gap-1 border ${aspectRatio === "1:1" ? "bg-black text-white" : "bg-white text-gray-700 hover:bg-gray-50"}`}><Smartphone className="w-3 h-3" /> 正方形</button>
+            <button type="button" onClick={() => setAspectRatio("original")} className={`px-3 py-1.5 rounded-full text-xs font-medium flex items-center gap-1 border ${aspectRatio === "original" ? "bg-black text-white" : "bg-white text-gray-700 hover:bg-gray-50"}`}><ImageIcon className="w-3 h-3" /> 元の比率</button>
+            <button type="button" onClick={() => setAspectRatio("custom")} className={`px-3 py-1.5 rounded-full text-xs font-medium flex items-center gap-1 border ${aspectRatio === "custom" ? "bg-black text-white" : "bg-white text-gray-700 hover:bg-gray-50"}`}><Maximize className="w-3 h-3" /> カスタム</button>
           </div>
         </div>
-        <div className="relative flex-1 bg-black w-full">
-          <Cropper image={imageSrc} crop={crop} zoom={zoom} aspect={aspectRatio === "1:1" ? 1 : imageAspectRatio} onCropChange={setCrop} onCropComplete={onCropComplete} onZoomChange={setZoom} />
+        <div className="flex-1 min-h-0 bg-black flex items-center justify-center p-4">
+          <ReactCrop
+            crop={crop}
+            onChange={c => setCrop(c)}
+            onComplete={c => setCompletedCrop(c)}
+            aspect={aspectRatio === "1:1" ? 1 : aspectRatio === "original" ? imageAspectRatio : undefined}
+            className="max-h-full"
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              ref={imgRef}
+              alt="Crop me"
+              src={imageSrc}
+              onLoad={onImageLoad}
+              className="max-h-full w-auto object-contain"
+            />
+          </ReactCrop>
         </div>
       </div>
     );

--- a/app/contests/[id]/upload/page.tsx
+++ b/app/contests/[id]/upload/page.tsx
@@ -49,12 +49,13 @@ export default function ContestUploadPage({ params }: { params: Promise<{ id: st
 
     let newCrop;
     if (initialAspect) {
+      const cropConfig = aspect > initialAspect
+        ? { unit: '%' as const, height: 100 }
+        : { unit: '%' as const, width: 100 };
+
       newCrop = centerCrop(
         makeAspectCrop(
-          {
-            unit: '%',
-            width: 90,
-          },
+          cropConfig,
           initialAspect,
           width,
           height,
@@ -63,17 +64,13 @@ export default function ContestUploadPage({ params }: { params: Promise<{ id: st
         height,
       );
     } else {
-      newCrop = centerCrop(
-        {
-          unit: '%',
-          width: 90,
-          height: 90,
-          x: 5,
-          y: 5
-        },
-        width,
-        height,
-      );
+      newCrop = {
+        unit: '%' as const,
+        width: 100,
+        height: 100,
+        x: 0,
+        y: 0
+      };
     }
     setCrop(newCrop);
   }
@@ -85,12 +82,13 @@ export default function ContestUploadPage({ params }: { params: Promise<{ id: st
 
         let newCrop;
         if (aspect) {
+          const cropConfig = imageAspectRatio > aspect
+            ? { unit: '%' as const, height: 100 }
+            : { unit: '%' as const, width: 100 };
+
           newCrop = centerCrop(
             makeAspectCrop(
-              {
-                unit: '%',
-                width: 90,
-              },
+              cropConfig,
               aspect,
               width,
               height,
@@ -99,17 +97,13 @@ export default function ContestUploadPage({ params }: { params: Promise<{ id: st
             height,
           );
         } else {
-          newCrop = centerCrop(
-            {
-              unit: '%',
-              width: 90,
-              height: 90,
-              x: 5,
-              y: 5
-            },
-            width,
-            height,
-          );
+          newCrop = {
+            unit: '%' as const,
+            width: 100,
+            height: 100,
+            x: 0,
+            y: 0
+          };
         }
         setCrop(newCrop);
     }
@@ -226,7 +220,7 @@ export default function ContestUploadPage({ params }: { params: Promise<{ id: st
             <button type="button" onClick={() => setAspectRatio("custom")} className={`px-3 py-1.5 rounded-full text-xs font-medium flex items-center gap-1 border ${aspectRatio === "custom" ? "bg-black text-white" : "bg-white text-gray-700 hover:bg-gray-50"}`}><Maximize className="w-3 h-3" /> カスタム</button>
           </div>
         </div>
-        <div className="flex-1 min-h-0 bg-black flex items-center justify-center p-4">
+        <div className="flex-1 min-h-0 bg-black flex items-center justify-center p-1">
           <ReactCrop
             crop={crop}
             onChange={c => setCrop(c)}

--- a/app/contests/[id]/upload/page.tsx
+++ b/app/contests/[id]/upload/page.tsx
@@ -47,19 +47,34 @@ export default function ContestUploadPage({ params }: { params: Promise<{ id: st
 
     const initialAspect = aspectRatio === "1:1" ? 1 : aspectRatio === "original" ? aspect : undefined;
 
-    const newCrop = centerCrop(
-      makeAspectCrop(
+    let newCrop;
+    if (initialAspect) {
+      newCrop = centerCrop(
+        makeAspectCrop(
+          {
+            unit: '%',
+            width: 90,
+          },
+          initialAspect,
+          width,
+          height,
+        ),
+        width,
+        height,
+      );
+    } else {
+      newCrop = centerCrop(
         {
           unit: '%',
           width: 90,
+          height: 90,
+          x: 5,
+          y: 5
         },
-        initialAspect,
         width,
         height,
-      ),
-      width,
-      height,
-    );
+      );
+    }
     setCrop(newCrop);
   }
 
@@ -68,19 +83,34 @@ export default function ContestUploadPage({ params }: { params: Promise<{ id: st
         const { width, height } = imgRef.current;
         const aspect = aspectRatio === "1:1" ? 1 : aspectRatio === "original" ? imageAspectRatio : undefined;
 
-        const newCrop = centerCrop(
-          makeAspectCrop(
+        let newCrop;
+        if (aspect) {
+          newCrop = centerCrop(
+            makeAspectCrop(
+              {
+                unit: '%',
+                width: 90,
+              },
+              aspect,
+              width,
+              height,
+            ),
+            width,
+            height,
+          );
+        } else {
+          newCrop = centerCrop(
             {
               unit: '%',
               width: 90,
+              height: 90,
+              x: 5,
+              y: 5
             },
-            aspect,
             width,
             height,
-          ),
-          width,
-          height,
-        );
+          );
+        }
         setCrop(newCrop);
     }
   }, [aspectRatio, imageAspectRatio, imageSrc]);

--- a/components/EditProfileForm.tsx
+++ b/components/EditProfileForm.tsx
@@ -4,33 +4,13 @@ import { useActionState, useState, useRef, useEffect, useCallback } from 'react'
 import dynamic from 'next/dynamic';
 import { updateProfile } from '@/app/actions/user';
 import { Camera, Check, X } from 'lucide-react';
+import ReactCrop, { centerCrop, makeAspectCrop, Crop, PixelCrop, convertToPixelCrop } from 'react-image-crop';
+import 'react-image-crop/dist/ReactCrop.css';
 import { getCroppedImg } from '@/lib/image';
 import { uploadImageToSupabase } from '@/lib/client-upload';
 import { Spinner } from '@/components/ui/spinner';
 import { SelfRoleSelector } from '@/components/SelfRoleSelector';
 
-type LazyCropperProps = {
-  image: string;
-  crop: { x: number; y: number };
-  zoom: number;
-  aspect: number;
-  cropShape: 'rect' | 'round';
-  showGrid: boolean;
-  onCropChange: (crop: { x: number; y: number }) => void;
-  onCropComplete: (croppedArea: Area, croppedAreaPixels: Area) => void;
-  onZoomChange: (zoom: number) => void;
-};
-
-const Cropper = dynamic<LazyCropperProps>(
-  () =>
-    import('react-easy-crop').then((mod) => {
-      const CropperComponent = mod.default;
-      return function LazyCropper(props: LazyCropperProps) {
-        return <CropperComponent {...props} />;
-      };
-    }),
-  { ssr: false }
-);
 
 type User = {
     username: string;
@@ -50,10 +30,10 @@ export default function EditProfileForm({ user, onClose }: { user: User, onClose
   const [oshi, setOshi] = useState(user.oshi || '');
   
   const [imageSrc, setImageSrc] = useState<string | null>(null);
-  const [crop, setCrop] = useState({ x: 0, y: 0 });
-  const [zoom, setZoom] = useState(1);
-  const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | null>(null);
+  const [crop, setCrop] = useState<Crop>();
+  const [completedCrop, setCompletedCrop] = useState<PixelCrop>();
   const [isUploading, setIsUploading] = useState(false);
+  const imgRef = useRef<HTMLImageElement>(null);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -63,9 +43,23 @@ export default function EditProfileForm({ user, onClose }: { user: User, onClose
       }
   }, [state, onClose]);
 
-  const onCropComplete = useCallback((croppedArea: Area, croppedAreaPixels: Area) => {
-    setCroppedAreaPixels(croppedAreaPixels);
-  }, []);
+  function onImageLoad(e: React.SyntheticEvent<HTMLImageElement>) {
+    const { width, height } = e.currentTarget;
+    const newCrop = centerCrop(
+      makeAspectCrop(
+        {
+          unit: '%',
+          width: 90,
+        },
+        1,
+        width,
+        height,
+      ),
+      width,
+      height,
+    );
+    setCrop(newCrop);
+  }
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -79,12 +73,32 @@ export default function EditProfileForm({ user, onClose }: { user: User, onClose
     e.target.value = '';
   };
 
-  const applyCrop = async () => {
-    if (!imageSrc || !croppedAreaPixels) return;
+  const applyCrop = useCallback(async () => {
+    if (!imageSrc || !imgRef.current) return;
+
+    const image = imgRef.current;
+    let finalCrop = completedCrop;
+
+    if (!finalCrop && crop) {
+        finalCrop = convertToPixelCrop(crop, image.width, image.height);
+    }
+
+    if (!finalCrop) return;
+
+    const scaleX = image.naturalWidth / image.width;
+    const scaleY = image.naturalHeight / image.height;
+
+    const pixelCrop = {
+        x: finalCrop.x * scaleX,
+        y: finalCrop.y * scaleY,
+        width: finalCrop.width * scaleX,
+        height: finalCrop.height * scaleY,
+    };
+
     try {
         const croppedImage = await getCroppedImg(
             imageSrc,
-            croppedAreaPixels,
+            pixelCrop,
             128 // Output size for avatar
         );
         setAvatarPreview(croppedImage);
@@ -92,7 +106,7 @@ export default function EditProfileForm({ user, onClose }: { user: User, onClose
     } catch (e) {
         console.error(e);
     }
-  };
+  }, [imageSrc, completedCrop, crop]);
 
   const cancelCrop = () => {
       setImageSrc(null);
@@ -127,42 +141,43 @@ export default function EditProfileForm({ user, onClose }: { user: User, onClose
   // If in cropping mode
   if (imageSrc) {
       return (
-        <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/90">
-            <div className="w-full max-w-md h-[500px] flex flex-col relative bg-black">
-                 <div className="relative flex-1 w-full bg-black">
-                    <Cropper
-                        image={imageSrc}
-                        crop={crop}
-                        zoom={zoom}
-                        aspect={1}
-                        cropShape="round" // Round crop guide for avatar
-                        showGrid={false}
-                        onCropChange={setCrop}
-                        onCropComplete={onCropComplete}
-                        onZoomChange={setZoom}
-                    />
-                </div>
-                 <div className="p-4 flex items-center justify-between gap-4 bg-white/10 backdrop-blur-sm absolute bottom-0 w-full">
-                     <div className="flex-1">
-                         <input
-                            type="range"
-                            value={zoom}
-                            min={1}
-                            max={3}
-                            step={0.1}
-                            onChange={(e) => setZoom(Number(e.target.value))}
-                            className="w-full h-1 bg-gray-500 rounded-lg appearance-none cursor-pointer"
-                        />
-                     </div>
-                     <div className="flex items-center gap-4">
-                         <button onClick={cancelCrop} className="text-white hover:text-gray-300">
-                             <X className="w-6 h-6" />
-                         </button>
-                         <button onClick={applyCrop} className="text-white hover:text-gray-300">
-                             <Check className="w-6 h-6" />
-                         </button>
+        <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/90 p-4">
+            <div className="w-full max-w-md flex flex-col bg-zinc-900 rounded-xl overflow-hidden shadow-2xl">
+                 <div className="p-4 border-b border-zinc-800 flex items-center justify-between">
+                     <h3 className="text-white font-bold">アイコンを調整</h3>
+                     <div className="flex items-center gap-2">
+                        <button onClick={cancelCrop} className="p-2 text-zinc-400 hover:text-white transition-colors">
+                            <X className="w-6 h-6" />
+                        </button>
+                        <button onClick={applyCrop} className="p-2 text-white bg-indigo-600 rounded-full hover:bg-indigo-500 transition-colors">
+                            <Check className="w-6 h-6" />
+                        </button>
                      </div>
                  </div>
+                 <div className="relative flex-1 flex items-center justify-center p-8 bg-black min-h-[300px]">
+                    <style>{`
+                        .avatar-cropper .ReactCrop__child-wrapper {
+                            border-radius: 9999px;
+                        }
+                    `}</style>
+                    <ReactCrop
+                        crop={crop}
+                        onChange={c => setCrop(c)}
+                        onComplete={c => setCompletedCrop(c)}
+                        aspect={1}
+                        circularCrop
+                        className="avatar-cropper"
+                    >
+                        {/* eslint-disable-next-line @next/next/no-img-element */}
+                        <img
+                            ref={imgRef}
+                            alt="Crop me"
+                            src={imageSrc}
+                            onLoad={onImageLoad}
+                            className="max-h-[60vh] w-auto object-contain"
+                        />
+                    </ReactCrop>
+                </div>
             </div>
         </div>
       );

--- a/components/EditProfileForm.tsx
+++ b/components/EditProfileForm.tsx
@@ -49,7 +49,7 @@ export default function EditProfileForm({ user, onClose }: { user: User, onClose
       makeAspectCrop(
         {
           unit: '%',
-          width: 90,
+          width: 100,
         },
         1,
         width,

--- a/components/UploadForm.tsx
+++ b/components/UploadForm.tsx
@@ -2,8 +2,9 @@
 
 import { useState, useRef, useCallback, useEffect } from "react";
 import { createPost } from "@/app/actions/post";
-import { Camera, Check, X, Smartphone, Image as ImageIcon, Video, Loader2 } from "lucide-react";
-import Cropper from "react-easy-crop";
+import { Camera, Check, X, Smartphone, Image as ImageIcon, Video, Loader2, Maximize } from "lucide-react";
+import ReactCrop, { centerCrop, makeAspectCrop, Crop, PixelCrop, convertToPixelCrop } from 'react-image-crop';
+import 'react-image-crop/dist/ReactCrop.css';
 import { getCroppedImg } from "@/lib/image";
 import { uploadImageToSupabase } from "@/lib/client-upload";
 import { Spinner } from "@/components/ui/spinner";
@@ -16,7 +17,7 @@ import { fetchLinkMetadata } from "@/app/actions/metadata";
 import { HexColorPicker } from "react-colorful";
 
 type Area = { x: number; y: number; width: number; height: number };
-type AspectRatio = "1:1" | "original";
+type AspectRatio = "1:1" | "original" | "custom";
 type MediaType = "IMAGE" | "VIDEO";
 
 interface UploadFormProps {
@@ -40,9 +41,8 @@ export default function UploadForm({ initialComment = "", initialHashtags = "", 
   // State for Image Text Editing
   const [editingImageSrc, setEditingImageSrc] = useState<string | null>(null);
 
-  const [crop, setCrop] = useState({ x: 0, y: 0 });
-  const [zoom, setZoom] = useState(1);
-  const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | null>(null);
+  const [crop, setCrop] = useState<Crop>();
+  const [completedCrop, setCompletedCrop] = useState<PixelCrop>();
   const [croppedImages, setCroppedImages] = useState<string[]>([]);
 
   // Local upload state (replaced global state)
@@ -55,6 +55,7 @@ export default function UploadForm({ initialComment = "", initialHashtags = "", 
   const [isSpoiler, setIsSpoiler] = useState(false);
   const [aspectRatio, setAspectRatio] = useState<AspectRatio>("1:1");
   const [imageAspectRatio, setImageAspectRatio] = useState<number>(1);
+  const imgRef = useRef<HTMLImageElement>(null);
 
   // GIF Conversion State
   const [isConverting, setIsConverting] = useState(false);
@@ -127,12 +128,50 @@ export default function UploadForm({ initialComment = "", initialHashtags = "", 
       return () => setSidebarVisible(true);
   }, [mediaType, mediaFile, editingImageSrc, setSidebarVisible]);
 
-  const onCropComplete = useCallback(
-    (croppedArea: Area, croppedAreaPixels: Area) => {
-      setCroppedAreaPixels(croppedAreaPixels);
-    },
-    []
-  );
+  function onImageLoad(e: React.SyntheticEvent<HTMLImageElement>) {
+    const { width, height } = e.currentTarget;
+    const aspect = width / height;
+    setImageAspectRatio(aspect);
+
+    const initialAspect = aspectRatio === "1:1" ? 1 : aspectRatio === "original" ? aspect : undefined;
+
+    const newCrop = centerCrop(
+      makeAspectCrop(
+        {
+          unit: '%',
+          width: 90,
+        },
+        initialAspect,
+        width,
+        height,
+      ),
+      width,
+      height,
+    );
+    setCrop(newCrop);
+  }
+
+  useEffect(() => {
+    if (mediaSrc && imgRef.current) {
+        const { width, height } = imgRef.current;
+        const aspect = aspectRatio === "1:1" ? 1 : aspectRatio === "original" ? imageAspectRatio : undefined;
+
+        const newCrop = centerCrop(
+          makeAspectCrop(
+            {
+              unit: '%',
+              width: 90,
+            },
+            aspect,
+            width,
+            height,
+          ),
+          width,
+          height,
+        );
+        setCrop(newCrop);
+    }
+  }, [aspectRatio, imageAspectRatio, mediaSrc]);
 
   const loadFFmpeg = async () => {
     if (ffmpegRef.current) return ffmpegRef.current;
@@ -226,31 +265,46 @@ export default function UploadForm({ initialComment = "", initialHashtags = "", 
   };
 
   const handleCropConfirm = useCallback(async () => {
-    if (!mediaSrc || !croppedAreaPixels) return;
+    if (!mediaSrc || !imgRef.current) return;
+
+    const image = imgRef.current;
+    let finalCrop = completedCrop;
+
+    if (!finalCrop && crop) {
+        finalCrop = convertToPixelCrop(crop, image.width, image.height);
+    }
+
+    if (!finalCrop) return;
+
+    const scaleX = image.naturalWidth / image.width;
+    const scaleY = image.naturalHeight / image.height;
+
+    const pixelCrop = {
+        x: finalCrop.x * scaleX,
+        y: finalCrop.y * scaleY,
+        width: finalCrop.width * scaleX,
+        height: finalCrop.height * scaleY,
+    };
+
     try {
       let outputWidth = 512;
       let outputHeight = 512;
 
-      if (aspectRatio === "original") {
-        // Calculate dimensions such that long side is 512px
-        const width = croppedAreaPixels.width;
-        const height = croppedAreaPixels.height;
-        const aspect = width / height;
+      const aspect = pixelCrop.width / pixelCrop.height;
 
-        if (width > height) {
+      if (aspect > 1) {
           // Landscape
           outputWidth = 512;
           outputHeight = Math.round(512 / aspect);
-        } else {
+      } else {
           // Portrait
           outputHeight = 512;
           outputWidth = Math.round(512 * aspect);
-        }
       }
 
       const cropped = await getCroppedImg(
         mediaSrc,
-        croppedAreaPixels,
+        pixelCrop,
         { width: outputWidth, height: outputHeight }
       );
 
@@ -261,11 +315,10 @@ export default function UploadForm({ initialComment = "", initialHashtags = "", 
 
       // Hide Cropper
       setMediaSrc(null);
-      setZoom(1);
     } catch (e) {
       console.error(e);
     }
-  }, [mediaSrc, croppedAreaPixels, aspectRatio]);
+  }, [mediaSrc, completedCrop, crop]);
 
   const handleTextEditComplete = (finalImageSrc: string) => {
       setCroppedImages(prev => [...prev, finalImageSrc]);
@@ -274,7 +327,6 @@ export default function UploadForm({ initialComment = "", initialHashtags = "", 
 
   const cancelCrop = () => {
     setMediaSrc(null);
-    setZoom(1);
   };
 
   const cancelTextEdit = () => {
@@ -430,22 +482,10 @@ export default function UploadForm({ initialComment = "", initialHashtags = "", 
   // Image Cropper
   if (mediaType === "IMAGE" && mediaSrc) {
     return (
-      <div className="flex flex-col h-[calc(100vh-100px)]">
-        <div className="p-4 bg-white dark:bg-zinc-900 border-b flex flex-col gap-4">
+      <div className="flex flex-col h-[calc(100vh-64px)] bg-black overflow-hidden">
+        <div className="p-4 bg-white dark:bg-zinc-900 border-b flex flex-col gap-4 shrink-0">
           <div className="flex items-center justify-between gap-4">
-            <div className="flex-1">
-              <label className="text-xs text-gray-500 mb-1 block">ズーム</label>
-              <input
-                type="range"
-                value={zoom}
-                min={1}
-                max={3}
-                step={0.1}
-                aria-labelledby="Zoom"
-                onChange={(e) => setZoom(Number(e.target.value))}
-                className="w-full h-1 bg-gray-200 rounded-lg appearance-none cursor-pointer"
-              />
-            </div>
+            <h3 className="font-bold text-sm">範囲を選択</h3>
             <div className="flex items-center gap-2">
               <button
                 type="button"
@@ -466,7 +506,7 @@ export default function UploadForm({ initialComment = "", initialHashtags = "", 
             </div>
           </div>
 
-          <div className="flex justify-center gap-4">
+          <div className="flex justify-center gap-2">
             <button
               type="button"
               onClick={() => setAspectRatio("1:1")}
@@ -477,7 +517,7 @@ export default function UploadForm({ initialComment = "", initialHashtags = "", 
               }`}
             >
               <Smartphone className="w-3 h-3" />
-              正方形 (1:1)
+              正方形
             </button>
             <button
               type="button"
@@ -491,18 +531,37 @@ export default function UploadForm({ initialComment = "", initialHashtags = "", 
               <ImageIcon className="w-3 h-3" />
               オリジナル
             </button>
+            <button
+              type="button"
+              onClick={() => setAspectRatio("custom")}
+              className={`px-3 py-1.5 rounded-full text-xs font-medium flex items-center gap-1 border ${
+                aspectRatio === "custom"
+                  ? "bg-black text-white border-black dark:bg-white dark:text-black"
+                  : "bg-white text-gray-700 border-gray-300 hover:bg-gray-50 dark:bg-zinc-800 dark:text-gray-300 dark:border-zinc-700"
+              }`}
+            >
+              <Maximize className="w-3 h-3" />
+              カスタム
+            </button>
           </div>
         </div>
-        <div className="relative flex-1 bg-black w-full">
-          <Cropper
-            image={mediaSrc}
+        <div className="flex-1 min-h-0 bg-black flex items-center justify-center p-4">
+          <ReactCrop
             crop={crop}
-            zoom={zoom}
-            aspect={aspectRatio === "1:1" ? 1 : imageAspectRatio}
-            onCropChange={setCrop}
-            onCropComplete={onCropComplete}
-            onZoomChange={setZoom}
-          />
+            onChange={c => setCrop(c)}
+            onComplete={c => setCompletedCrop(c)}
+            aspect={aspectRatio === "1:1" ? 1 : aspectRatio === "original" ? imageAspectRatio : undefined}
+            className="max-h-full"
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              ref={imgRef}
+              alt="Crop me"
+              src={mediaSrc}
+              onLoad={onImageLoad}
+              className="max-h-full w-auto object-contain"
+            />
+          </ReactCrop>
         </div>
       </div>
     );

--- a/components/UploadForm.tsx
+++ b/components/UploadForm.tsx
@@ -135,19 +135,34 @@ export default function UploadForm({ initialComment = "", initialHashtags = "", 
 
     const initialAspect = aspectRatio === "1:1" ? 1 : aspectRatio === "original" ? aspect : undefined;
 
-    const newCrop = centerCrop(
-      makeAspectCrop(
+    let newCrop;
+    if (initialAspect) {
+      newCrop = centerCrop(
+        makeAspectCrop(
+          {
+            unit: '%',
+            width: 90,
+          },
+          initialAspect,
+          width,
+          height,
+        ),
+        width,
+        height,
+      );
+    } else {
+      newCrop = centerCrop(
         {
           unit: '%',
           width: 90,
+          height: 90,
+          x: 5,
+          y: 5
         },
-        initialAspect,
         width,
         height,
-      ),
-      width,
-      height,
-    );
+      );
+    }
     setCrop(newCrop);
   }
 
@@ -156,19 +171,34 @@ export default function UploadForm({ initialComment = "", initialHashtags = "", 
         const { width, height } = imgRef.current;
         const aspect = aspectRatio === "1:1" ? 1 : aspectRatio === "original" ? imageAspectRatio : undefined;
 
-        const newCrop = centerCrop(
-          makeAspectCrop(
+        let newCrop;
+        if (aspect) {
+          newCrop = centerCrop(
+            makeAspectCrop(
+              {
+                unit: '%',
+                width: 90,
+              },
+              aspect,
+              width,
+              height,
+            ),
+            width,
+            height,
+          );
+        } else {
+          newCrop = centerCrop(
             {
               unit: '%',
               width: 90,
+              height: 90,
+              x: 5,
+              y: 5
             },
-            aspect,
             width,
             height,
-          ),
-          width,
-          height,
-        );
+          );
+        }
         setCrop(newCrop);
     }
   }, [aspectRatio, imageAspectRatio, mediaSrc]);

--- a/components/UploadForm.tsx
+++ b/components/UploadForm.tsx
@@ -137,12 +137,13 @@ export default function UploadForm({ initialComment = "", initialHashtags = "", 
 
     let newCrop;
     if (initialAspect) {
+      const cropConfig = aspect > initialAspect
+        ? { unit: '%' as const, height: 100 }
+        : { unit: '%' as const, width: 100 };
+
       newCrop = centerCrop(
         makeAspectCrop(
-          {
-            unit: '%',
-            width: 90,
-          },
+          cropConfig,
           initialAspect,
           width,
           height,
@@ -151,17 +152,13 @@ export default function UploadForm({ initialComment = "", initialHashtags = "", 
         height,
       );
     } else {
-      newCrop = centerCrop(
-        {
-          unit: '%',
-          width: 90,
-          height: 90,
-          x: 5,
-          y: 5
-        },
-        width,
-        height,
-      );
+      newCrop = {
+        unit: '%' as const,
+        width: 100,
+        height: 100,
+        x: 0,
+        y: 0
+      };
     }
     setCrop(newCrop);
   }
@@ -173,12 +170,13 @@ export default function UploadForm({ initialComment = "", initialHashtags = "", 
 
         let newCrop;
         if (aspect) {
+          const cropConfig = imageAspectRatio > aspect
+            ? { unit: '%' as const, height: 100 }
+            : { unit: '%' as const, width: 100 };
+
           newCrop = centerCrop(
             makeAspectCrop(
-              {
-                unit: '%',
-                width: 90,
-              },
+              cropConfig,
               aspect,
               width,
               height,
@@ -187,17 +185,13 @@ export default function UploadForm({ initialComment = "", initialHashtags = "", 
             height,
           );
         } else {
-          newCrop = centerCrop(
-            {
-              unit: '%',
-              width: 90,
-              height: 90,
-              x: 5,
-              y: 5
-            },
-            width,
-            height,
-          );
+          newCrop = {
+            unit: '%' as const,
+            width: 100,
+            height: 100,
+            x: 0,
+            y: 0
+          };
         }
         setCrop(newCrop);
     }
@@ -282,13 +276,6 @@ export default function UploadForm({ initialComment = "", initialHashtags = "", 
         const reader = new FileReader();
         reader.addEventListener("load", () => {
           setMediaSrc(reader.result as string);
-
-          // Load image to get dimensions
-          const img = new Image();
-          img.onload = () => {
-            setImageAspectRatio(img.width / img.height);
-          };
-          img.src = reader.result as string;
         });
         reader.readAsDataURL(file);
     }
@@ -575,7 +562,7 @@ export default function UploadForm({ initialComment = "", initialHashtags = "", 
             </button>
           </div>
         </div>
-        <div className="flex-1 min-h-0 bg-black flex items-center justify-center p-4">
+        <div className="flex-1 min-h-0 bg-black flex items-center justify-center p-1">
           <ReactCrop
             crop={crop}
             onChange={c => setCrop(c)}

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "react": "19.2.0",
         "react-colorful": "^5.6.1",
         "react-dom": "19.2.0",
-        "react-easy-crop": "^5.5.6",
+        "react-image-crop": "^11.0.10",
         "recharts": "^3.8.1",
         "tailwind-merge": "^3.4.0",
         "tailwindcss-animate": "^1.0.7",
@@ -6829,12 +6829,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/normalize-wheel": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/normalize-wheel/-/normalize-wheel-1.0.1.tgz",
-      "integrity": "sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -7452,20 +7446,6 @@
         "react": "^19.2.0"
       }
     },
-    "node_modules/react-easy-crop": {
-      "version": "5.5.6",
-      "resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-5.5.6.tgz",
-      "integrity": "sha512-Jw3/ozs8uXj3NpL511Suc4AHY+mLRO23rUgipXvNYKqezcFSYHxe4QXibBymkOoY6oOtLVMPO2HNPRHYvMPyTw==",
-      "license": "MIT",
-      "dependencies": {
-        "normalize-wheel": "^1.0.1",
-        "tslib": "^2.0.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.4.0",
-        "react-dom": ">=16.4.0"
-      }
-    },
     "node_modules/react-error-boundary": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-6.0.0.tgz",
@@ -7474,6 +7454,15 @@
       "dependencies": {
         "@babel/runtime": "^7.12.5"
       },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
+    },
+    "node_modules/react-image-crop": {
+      "version": "11.0.10",
+      "resolved": "https://registry.npmjs.org/react-image-crop/-/react-image-crop-11.0.10.tgz",
+      "integrity": "sha512-+5FfDXUgYLLqBh1Y/uQhIycpHCbXkI50a+nbfkB1C0xXXUTwkisHDo2QCB1SQJyHCqIuia4FeyReqXuMDKWQTQ==",
+      "license": "ISC",
       "peerDependencies": {
         "react": ">=16.13.1"
       }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react": "19.2.0",
     "react-colorful": "^5.6.1",
     "react-dom": "19.2.0",
-    "react-easy-crop": "^5.5.6",
+    "react-image-crop": "^11.0.10",
     "recharts": "^3.8.1",
     "tailwind-merge": "^3.4.0",
     "tailwindcss-animate": "^1.0.7",


### PR DESCRIPTION
Implemented a new image cropping interface using `react-image-crop` to replace `react-easy-crop`. This change introduces a "Custom" cropping mode for free-form trimming and switches the interaction model to a more intuitive "draggable corner" style, as requested. The update is applied consistently to the main post upload form, contest entry form, and profile avatar editor. The zoom slider has been removed as resizing the frame now provides the same functionality more intuitively.

---
*PR created automatically by Jules for task [11069297427111270227](https://jules.google.com/task/11069297427111270227) started by @testuser0123-web*