### PR TITLE
Fix special character rendering and "tofu" in kaomoji

### DIFF
--- a/app/admin/inbox/page.tsx
+++ b/app/admin/inbox/page.tsx
@@ -75,7 +75,7 @@ export default async function AdminInboxPage() {
                 </div>
               </div>
 
-              <div className="whitespace-pre-wrap text-gray-800 dark:text-gray-200 leading-relaxed bg-gray-50 dark:bg-gray-950/50 p-4 rounded-md">
+              <div className="whitespace-pre-wrap text-gray-800 dark:text-gray-200 leading-relaxed bg-gray-50 dark:bg-gray-950/50 p-4 rounded-md font-sans">
                 {suggestion.content}
               </div>
             </div>

--- a/app/admin/inbox/page.tsx
+++ b/app/admin/inbox/page.tsx
@@ -75,7 +75,7 @@ export default async function AdminInboxPage() {
                 </div>
               </div>
 
-              <div className="whitespace-pre-wrap text-gray-800 dark:text-gray-200 leading-relaxed bg-gray-50 dark:bg-gray-950/50 p-4 rounded-md font-sans">
+              <div className="whitespace-pre-wrap text-gray-800 dark:text-gray-200 leading-relaxed bg-gray-50 dark:bg-gray-950/50 p-4 rounded-md kaomoji-safe">
                 {suggestion.content}
               </div>
             </div>

--- a/app/diary/[id]/DiaryDetailClient.tsx
+++ b/app/diary/[id]/DiaryDetailClient.tsx
@@ -198,7 +198,7 @@ export default function DiaryDetailClient({ diary, currentUserId }: { diary: any
                                )}
                            </div>
                         </div>
-                        <p className="text-gray-700 dark:text-gray-300 whitespace-pre-wrap">{comment.text}</p>
+                        <p className="kaomoji-safe text-gray-700 dark:text-gray-300 whitespace-pre-wrap">{comment.text}</p>
                      </div>
                   </div>
                ))

--- a/app/globals.css
+++ b/app/globals.css
@@ -17,7 +17,7 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
+  --font-sans: var(--font-geist-sans), var(--font-noto-sans-jp), -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Hiragino Sans", "Hiragino Kaku Gothic ProN", Meiryo, "Segoe UI Symbol", "Apple Color Emoji", sans-serif;
   --font-mono: var(--font-geist-mono);
 }
 
@@ -25,5 +25,5 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-family: var(--font-geist-sans), var(--font-noto-sans-jp), -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Hiragino Sans", "Hiragino Kaku Gothic ProN", Meiryo, "Segoe UI Symbol", "Apple Color Emoji", sans-serif;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -17,7 +17,7 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans), var(--font-noto-sans-jp), -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Hiragino Sans", "Hiragino Kaku Gothic ProN", Meiryo, "Segoe UI Symbol", "Apple Color Emoji", sans-serif;
+  --font-sans: var(--font-geist-sans), var(--font-noto-sans), var(--font-noto-sans-jp), -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Hiragino Sans", "Hiragino Kaku Gothic ProN", Meiryo, "Segoe UI Symbol", "Apple Color Emoji", sans-serif;
   --font-mono: var(--font-geist-mono);
 }
 
@@ -25,5 +25,5 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: var(--font-geist-sans), var(--font-noto-sans-jp), -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Hiragino Sans", "Hiragino Kaku Gothic ProN", Meiryo, "Segoe UI Symbol", "Apple Color Emoji", sans-serif;
+  font-family: var(--font-geist-sans), var(--font-noto-sans), var(--font-noto-sans-jp), -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Hiragino Sans", "Hiragino Kaku Gothic ProN", Meiryo, "Segoe UI Symbol", "Apple Color Emoji", sans-serif;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -5,7 +5,10 @@
 /* Specialized font stack for Kaomoji and special symbols */
 @font-face {
   font-family: 'KaomojiSupport';
-  /* Prioritize fonts known for excellent symbol and combining mark support */
+  /* Prioritize fonts known for excellent symbol and combining mark support.
+     Web fonts (Noto Sans Symbols) are handled by the browser via the CSS variables
+     in the font-family list, so we focus on local system fonts here for the @font-face.
+  */
   src:
     local('Apple Symbols'),        /* macOS/iOS */
     local('Segoe UI Symbol'),     /* Windows */
@@ -17,15 +20,7 @@
     local('MS PGothic'),          /* Classic Japanese web fonts for AA/Kaomoji */
     local('Symbola'),             /* Common symbol font */
     local('Arial Unicode MS');    /* Comprehensive fallback */
-  /* Target Unicode ranges used in common Kaomoji and special characters.
-     We include the base characters (like halfwidth katakana) along with combining marks
-     to ensure the browser uses the same font for both, which is critical for correct positioning.
-     U+02B0-036F: Modifier Letters & Combining Diacritical Marks
-     U+1DC0-1DFF: Combining Diacritical Marks Supplement (Critical for the reported case)
-     U+2000-2BFF: General Punctuation, Symbols, Arrows, etc.
-     U+3000-30FF: CJK Symbols, Hiragana, Katakana
-     U+FF00-FFEF: Halfwidth and Fullwidth Forms (Including halfwidth katakana)
-  */
+  /* Target Unicode ranges used in common Kaomoji and special characters. */
   unicode-range: U+02B0-036F, U+1DC0-1DFF, U+2000-2BFF, U+3000-30FF, U+FF00-FFEF;
 }
 
@@ -44,7 +39,7 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: 'KaomojiSupport', var(--font-geist-sans), var(--font-noto-sans), var(--font-noto-sans-jp), -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Hiragino Sans", "Hiragino Kaku Gothic ProN", Meiryo, "Segoe UI Symbol", "Apple Color Emoji", sans-serif;
+  --font-sans: 'KaomojiSupport', var(--font-noto-sans-symbols), var(--font-noto-sans-symbols-2), var(--font-noto-sans-jp), var(--font-noto-sans), var(--font-geist-sans), -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Hiragino Sans", "Hiragino Kaku Gothic ProN", Meiryo, "Segoe UI Symbol", "Apple Color Emoji", sans-serif;
   --font-mono: var(--font-geist-mono);
 }
 
@@ -52,9 +47,18 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: 'KaomojiSupport', var(--font-geist-sans), var(--font-noto-sans), var(--font-noto-sans-jp), -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Hiragino Sans", "Hiragino Kaku Gothic ProN", Meiryo, "Segoe UI Symbol", "Apple Color Emoji", sans-serif;
+  font-family: 'KaomojiSupport', var(--font-noto-sans-symbols), var(--font-noto-sans-symbols-2), var(--font-noto-sans-jp), var(--font-noto-sans), var(--font-geist-sans), -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Hiragino Sans", "Hiragino Kaku Gothic ProN", Meiryo, "Segoe UI Symbol", "Apple Color Emoji", sans-serif;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-variant-ligatures: contextual;
+  /* kernel and contextual ligatures only. Disable common ligatures that might mess up Kaomoji spacing */
+  font-feature-settings: "kern", "calt";
+}
+
+.kaomoji-safe {
+  /* Prioritize specialized symbol fonts over brand fonts */
+  font-family: 'KaomojiSupport', var(--font-noto-sans-symbols), var(--font-noto-sans-symbols-2), var(--font-noto-sans-jp), var(--font-noto-sans), -apple-system, sans-serif !important;
+  text-rendering: optimizeLegibility !important;
+  font-feature-settings: "kern", "calt" !important;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,6 +2,33 @@
 
 @plugin "tailwindcss-animate";
 
+/* Specialized font stack for Kaomoji and special symbols */
+@font-face {
+  font-family: 'KaomojiSupport';
+  /* Prioritize fonts known for excellent symbol and combining mark support */
+  src:
+    local('Apple Symbols'),        /* macOS/iOS */
+    local('Segoe UI Symbol'),     /* Windows */
+    local('Noto Sans Symbols'),   /* Linux/Android */
+    local('Noto Sans CJK JP'),    /* Android Japanese */
+    local('Hiragino Sans'),       /* macOS/iOS Japanese */
+    local('Hiragino Kaku Gothic ProN'),
+    local('Meiryo'),              /* Windows Japanese */
+    local('MS PGothic'),          /* Classic Japanese web fonts for AA/Kaomoji */
+    local('Symbola'),             /* Common symbol font */
+    local('Arial Unicode MS');    /* Comprehensive fallback */
+  /* Target Unicode ranges used in common Kaomoji and special characters.
+     We include the base characters (like halfwidth katakana) along with combining marks
+     to ensure the browser uses the same font for both, which is critical for correct positioning.
+     U+02B0-036F: Modifier Letters & Combining Diacritical Marks
+     U+1DC0-1DFF: Combining Diacritical Marks Supplement (Critical for the reported case)
+     U+2000-2BFF: General Punctuation, Symbols, Arrows, etc.
+     U+3000-30FF: CJK Symbols, Hiragana, Katakana
+     U+FF00-FFEF: Halfwidth and Fullwidth Forms (Including halfwidth katakana)
+  */
+  unicode-range: U+02B0-036F, U+1DC0-1DFF, U+2000-2BFF, U+3000-30FF, U+FF00-FFEF;
+}
+
 @custom-variant dark (&:where(.dark, .dark *));
 
 :root {
@@ -17,7 +44,7 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans), var(--font-noto-sans), var(--font-noto-sans-jp), -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Hiragino Sans", "Hiragino Kaku Gothic ProN", Meiryo, "Segoe UI Symbol", "Apple Color Emoji", sans-serif;
+  --font-sans: 'KaomojiSupport', var(--font-geist-sans), var(--font-noto-sans), var(--font-noto-sans-jp), -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Hiragino Sans", "Hiragino Kaku Gothic ProN", Meiryo, "Segoe UI Symbol", "Apple Color Emoji", sans-serif;
   --font-mono: var(--font-geist-mono);
 }
 
@@ -25,5 +52,9 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: var(--font-geist-sans), var(--font-noto-sans), var(--font-noto-sans-jp), -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Hiragino Sans", "Hiragino Kaku Gothic ProN", Meiryo, "Segoe UI Symbol", "Apple Color Emoji", sans-serif;
+  font-family: 'KaomojiSupport', var(--font-geist-sans), var(--font-noto-sans), var(--font-noto-sans-jp), -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Hiragino Sans", "Hiragino Kaku Gothic ProN", Meiryo, "Segoe UI Symbol", "Apple Color Emoji", sans-serif;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-variant-ligatures: contextual;
 }

--- a/app/inagawa/page.tsx
+++ b/app/inagawa/page.tsx
@@ -190,7 +190,7 @@ export default async function InagawaPage() {
                       <span className="text-sm text-muted-foreground">
                         {new Date(record.timestamp).toLocaleString('ja-JP', { timeZone: 'Asia/Tokyo' })}
                       </span>
-                      <span className="font-medium text-foreground">{record.message}</span>
+                      <span className="kaomoji-safe font-medium text-foreground">{record.message}</span>
                     </div>
                     <div className={`font-bold ${record.amount > 0 ? 'text-green-500' : 'text-red-500'}`}>
                       {record.amount > 0 ? `+${record.amount}` : record.amount}円

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,14 +20,13 @@ const geistMono = Geist_Mono({
 
 const notoSansJP = Noto_Sans_JP({
   variable: "--font-noto-sans-jp",
-  subsets: ["latin"],
   weight: ["400", "500", "700"],
   preload: false,
 });
 
 const notoSans = Noto_Sans({
   variable: "--font-noto-sans",
-  subsets: ["latin"],
+  subsets: ["latin", "latin-ext"],
   weight: ["400", "500", "700"],
   preload: false,
 });
@@ -88,7 +87,7 @@ export default async function RootLayout({
   return (
     <html lang="ja" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} ${notoSansJP.variable} ${notoSans.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} ${notoSansJP.variable} ${notoSans.variable} font-sans antialiased`}
       >
         <ThemeProvider
             attribute="class"

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist, Geist_Mono, Noto_Sans_JP } from "next/font/google";
 import "./globals.css";
 import { ThemeProvider } from "@/components/providers/theme-provider";
 import { UIProvider } from "@/components/providers/ui-provider";
@@ -16,6 +16,13 @@ const geistSans = Geist({
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
+});
+
+const notoSansJP = Noto_Sans_JP({
+  variable: "--font-noto-sans-jp",
+  subsets: ["latin"],
+  weight: ["400", "500", "700"],
+  preload: false, // Japanese subset is too large to preload normally
 });
 
 export const metadata: Metadata = {
@@ -74,7 +81,7 @@ export default async function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} ${notoSansJP.variable} antialiased`}
       >
         <ThemeProvider
             attribute="class"

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from "next";
-import { Geist, Geist_Mono, Noto_Sans_JP, Noto_Sans } from "next/font/google";
+import { Geist, Geist_Mono, Noto_Sans_JP, Noto_Sans, Noto_Sans_Symbols, Noto_Sans_Symbols_2 } from "next/font/google";
 import "./globals.css";
 import { ThemeProvider } from "@/components/providers/theme-provider";
 import { UIProvider } from "@/components/providers/ui-provider";
@@ -21,6 +21,18 @@ const geistMono = Geist_Mono({
 const notoSansJP = Noto_Sans_JP({
   variable: "--font-noto-sans-jp",
   weight: ["400", "500", "700"],
+  preload: false,
+});
+
+const notoSansSymbols = Noto_Sans_Symbols({
+  variable: "--font-noto-sans-symbols",
+  weight: ["400", "700"],
+  preload: false,
+});
+
+const notoSansSymbols2 = Noto_Sans_Symbols_2({
+  variable: "--font-noto-sans-symbols-2",
+  weight: ["400"],
   preload: false,
 });
 
@@ -87,7 +99,7 @@ export default async function RootLayout({
   return (
     <html lang="ja" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} ${notoSansJP.variable} ${notoSans.variable} font-sans antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} ${notoSansJP.variable} ${notoSans.variable} ${notoSansSymbols.variable} ${notoSansSymbols2.variable} font-sans antialiased`}
       >
         <ThemeProvider
             attribute="class"

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from "next";
-import { Geist, Geist_Mono, Noto_Sans_JP } from "next/font/google";
+import { Geist, Geist_Mono, Noto_Sans_JP, Noto_Sans } from "next/font/google";
 import "./globals.css";
 import { ThemeProvider } from "@/components/providers/theme-provider";
 import { UIProvider } from "@/components/providers/ui-provider";
@@ -22,7 +22,14 @@ const notoSansJP = Noto_Sans_JP({
   variable: "--font-noto-sans-jp",
   subsets: ["latin"],
   weight: ["400", "500", "700"],
-  preload: false, // Japanese subset is too large to preload normally
+  preload: false,
+});
+
+const notoSans = Noto_Sans({
+  variable: "--font-noto-sans",
+  subsets: ["latin"],
+  weight: ["400", "500", "700"],
+  preload: false,
 });
 
 export const metadata: Metadata = {
@@ -79,9 +86,9 @@ export default async function RootLayout({
   }
 
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="ja" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} ${notoSansJP.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} ${notoSansJP.variable} ${notoSans.variable} antialiased`}
       >
         <ThemeProvider
             attribute="class"

--- a/components/DiaryEditor.tsx
+++ b/components/DiaryEditor.tsx
@@ -128,7 +128,7 @@ const Toolbar = ({ onInsertImage }: { onInsertImage: () => void }) => {
 }
 
 const theme = {
-  paragraph: 'mb-4',
+  paragraph: 'kaomoji-safe mb-4',
   quote: 'border-l-4 border-gray-500 pl-4 italic my-4',
   heading: {
     h1: 'text-3xl font-bold mb-4',

--- a/components/Feed.tsx
+++ b/components/Feed.tsx
@@ -889,7 +889,7 @@ export default function Feed({ initialPosts, currentUserId, feedType, searchQuer
                   </div>
                 </div>
               ) : selectedPost.comment ? (
-                <p className="text-gray-900 dark:text-gray-100 break-words mb-2">
+                <p className="kaomoji-safe text-gray-900 dark:text-gray-100 break-words mb-2">
                     <Linkify>{selectedPost.comment}</Linkify>
                 </p>
               ) : null}
@@ -987,7 +987,7 @@ export default function Feed({ initialPosts, currentUserId, feedType, searchQuer
                                 <Link href={`/users/${comment.user.username}`} className="font-bold hover:underline mr-2 text-gray-900 dark:text-gray-100">
                                     {comment.user.username}
                                 </Link>
-                                <span className="text-gray-800 dark:text-gray-200 break-words">
+                                <span className="kaomoji-safe text-gray-800 dark:text-gray-200 break-words">
                                     <Linkify>{comment.text}</Linkify>
                                 </span>
                               </div>

--- a/components/InagawaModal.tsx
+++ b/components/InagawaModal.tsx
@@ -97,9 +97,9 @@ export default function InagawaModal({ session }: { session: Session | null }) {
 
         {step === 'intro' && (
           <div className="flex flex-col items-center text-center space-y-6 py-4">
-            <h2 className="text-2xl font-bold text-foreground">ᶘｲ^⇁^ﾅ川</h2>
+            <h2 className="kaomoji-safe text-2xl font-bold text-foreground">ᶘｲ^⇁^ﾅ川</h2>
             <div className="text-6xl animate-bounce">💸</div>
-            <p className="text-lg font-medium text-foreground">
+            <p className="kaomoji-safe text-lg font-medium text-foreground">
               「飼い主さん、おこづかいください！」
             </p>
             <div className="w-full space-y-3">
@@ -156,7 +156,7 @@ export default function InagawaModal({ session }: { session: Session | null }) {
                 <div className="text-6xl mb-4">😿</div>
              )}
 
-             <div className="text-lg text-foreground font-medium p-4 bg-muted/50 rounded-lg w-full">
+             <div className="kaomoji-safe text-lg text-foreground font-medium p-4 bg-muted/50 rounded-lg w-full">
                  {result.message}
              </div>
 

--- a/components/NotificationContent.tsx
+++ b/components/NotificationContent.tsx
@@ -34,10 +34,10 @@ export function RenderNotificationContent({ notification }: { notification: Noti
     const parts = content.split(`「${title}」`);
 
     // Safety check: if split didn't find the exact quoted title
-    if (parts.length < 2) return <p className="mt-1 text-gray-700 dark:text-gray-300 whitespace-pre-wrap text-sm font-sans">{content}</p>;
+    if (parts.length < 2) return <p className="mt-1 text-gray-700 dark:text-gray-300 whitespace-pre-wrap text-sm kaomoji-safe">{content}</p>;
 
     return (
-      <p className="mt-1 text-gray-700 dark:text-gray-300 whitespace-pre-wrap text-sm font-sans">
+      <p className="mt-1 text-gray-700 dark:text-gray-300 whitespace-pre-wrap text-sm kaomoji-safe">
         {parts.map((part, index) => {
           if (index === parts.length - 1) return <span key={index}>{part}</span>;
           return (
@@ -57,10 +57,10 @@ export function RenderNotificationContent({ notification }: { notification: Noti
     const title = metadata.diaryTitle;
     const parts = content.split(`「${title}」`);
 
-    if (parts.length < 2) return <p className="mt-1 text-gray-700 dark:text-gray-300 whitespace-pre-wrap text-sm font-sans">{content}</p>;
+    if (parts.length < 2) return <p className="mt-1 text-gray-700 dark:text-gray-300 whitespace-pre-wrap text-sm kaomoji-safe">{content}</p>;
 
     return (
-      <p className="mt-1 text-gray-700 dark:text-gray-300 whitespace-pre-wrap text-sm font-sans">
+      <p className="mt-1 text-gray-700 dark:text-gray-300 whitespace-pre-wrap text-sm kaomoji-safe">
          {parts.map((part, index) => {
           if (index === parts.length - 1) return <span key={index}>{part}</span>;
           return (
@@ -81,7 +81,7 @@ export function RenderNotificationContent({ notification }: { notification: Noti
     const linkHref = metadata.postId ? `/p/${metadata.postId}` : `/diary/${metadata.diaryId}`;
 
     return (
-      <p className="mt-1 text-gray-700 dark:text-gray-300 whitespace-pre-wrap text-sm font-sans">
+      <p className="mt-1 text-gray-700 dark:text-gray-300 whitespace-pre-wrap text-sm kaomoji-safe">
         {parts.map((part, index) => {
           if (index === parts.length - 1) return <span key={index}>{part}</span>;
           return (
@@ -98,7 +98,7 @@ export function RenderNotificationContent({ notification }: { notification: Noti
   }
 
   return (
-    <p className="mt-1 text-gray-700 dark:text-gray-300 whitespace-pre-wrap text-sm font-sans">
+    <p className="mt-1 text-gray-700 dark:text-gray-300 whitespace-pre-wrap text-sm kaomoji-safe">
       {notification.content}
     </p>
   );

--- a/components/NotificationContent.tsx
+++ b/components/NotificationContent.tsx
@@ -34,10 +34,10 @@ export function RenderNotificationContent({ notification }: { notification: Noti
     const parts = content.split(`「${title}」`);
 
     // Safety check: if split didn't find the exact quoted title
-    if (parts.length < 2) return <p className="mt-1 text-gray-700 dark:text-gray-300 whitespace-pre-wrap text-sm">{content}</p>;
+    if (parts.length < 2) return <p className="mt-1 text-gray-700 dark:text-gray-300 whitespace-pre-wrap text-sm font-sans">{content}</p>;
 
     return (
-      <p className="mt-1 text-gray-700 dark:text-gray-300 whitespace-pre-wrap text-sm">
+      <p className="mt-1 text-gray-700 dark:text-gray-300 whitespace-pre-wrap text-sm font-sans">
         {parts.map((part, index) => {
           if (index === parts.length - 1) return <span key={index}>{part}</span>;
           return (
@@ -57,10 +57,10 @@ export function RenderNotificationContent({ notification }: { notification: Noti
     const title = metadata.diaryTitle;
     const parts = content.split(`「${title}」`);
 
-    if (parts.length < 2) return <p className="mt-1 text-gray-700 dark:text-gray-300 whitespace-pre-wrap text-sm">{content}</p>;
+    if (parts.length < 2) return <p className="mt-1 text-gray-700 dark:text-gray-300 whitespace-pre-wrap text-sm font-sans">{content}</p>;
 
     return (
-      <p className="mt-1 text-gray-700 dark:text-gray-300 whitespace-pre-wrap text-sm">
+      <p className="mt-1 text-gray-700 dark:text-gray-300 whitespace-pre-wrap text-sm font-sans">
          {parts.map((part, index) => {
           if (index === parts.length - 1) return <span key={index}>{part}</span>;
           return (
@@ -81,7 +81,7 @@ export function RenderNotificationContent({ notification }: { notification: Noti
     const linkHref = metadata.postId ? `/p/${metadata.postId}` : `/diary/${metadata.diaryId}`;
 
     return (
-      <p className="mt-1 text-gray-700 dark:text-gray-300 whitespace-pre-wrap text-sm">
+      <p className="mt-1 text-gray-700 dark:text-gray-300 whitespace-pre-wrap text-sm font-sans">
         {parts.map((part, index) => {
           if (index === parts.length - 1) return <span key={index}>{part}</span>;
           return (
@@ -98,7 +98,7 @@ export function RenderNotificationContent({ notification }: { notification: Noti
   }
 
   return (
-    <p className="mt-1 text-gray-700 dark:text-gray-300 whitespace-pre-wrap text-sm">
+    <p className="mt-1 text-gray-700 dark:text-gray-300 whitespace-pre-wrap text-sm font-sans">
       {notification.content}
     </p>
   );

--- a/components/ProfileHeader.tsx
+++ b/components/ProfileHeader.tsx
@@ -95,7 +95,7 @@ export default function ProfileHeader({ user, currentUser, initialCounts, initia
       </div>
       
       <div className="flex items-center gap-1 mb-2">
-        <h2 className="text-xl font-bold">@{user.username}</h2>
+        <h2 className="kaomoji-safe text-xl font-bold">@{user.username}</h2>
         {user.isGold ? (
           <BadgeCheck className="w-5 h-5 text-yellow-500 fill-yellow-500/10" />
         ) : user.isVerified ? (
@@ -132,13 +132,13 @@ export default function ProfileHeader({ user, currentUser, initialCounts, initia
       {(user.bio || user.oshi) && (
           <div className="flex flex-col items-center gap-1 mb-4 max-w-md text-center px-4">
               {user.oshi && (
-                  <div className="text-pink-500 font-medium text-sm flex items-center gap-1">
+                  <div className="kaomoji-safe text-pink-500 font-medium text-sm flex items-center gap-1">
                       <Heart className="w-3 h-3 fill-current" />
                       <span>{user.oshi}</span>
                   </div>
               )}
               {user.bio && (
-                  <p className="text-gray-700 dark:text-gray-300 whitespace-pre-wrap text-sm">{user.bio}</p>
+                  <p className="kaomoji-safe text-gray-700 dark:text-gray-300 whitespace-pre-wrap text-sm">{user.bio}</p>
               )}
           </div>
       )}

--- a/components/SinglePost.tsx
+++ b/components/SinglePost.tsx
@@ -613,7 +613,7 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
              </div>
            </div>
          ) : post.comment ? (
-           <p className="text-gray-900 dark:text-gray-100 break-words mb-2">
+           <p className="text-gray-900 dark:text-gray-100 break-words mb-2 font-sans">
              <Linkify>{post.comment}</Linkify>
            </p>
          ) : null}
@@ -711,7 +711,7 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
                             <Link href={`/users/${comment.user.username}`} className="font-bold hover:underline mr-2 text-gray-900 dark:text-gray-100">
                                 {comment.user.username}
                             </Link>
-                            <span className="text-gray-800 dark:text-gray-200 break-words">
+                            <span className="text-gray-800 dark:text-gray-200 break-words font-sans">
                                 <Linkify>{comment.text}</Linkify>
                             </span>
                          </div>

--- a/components/SinglePost.tsx
+++ b/components/SinglePost.tsx
@@ -613,7 +613,7 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
              </div>
            </div>
          ) : post.comment ? (
-           <p className="text-gray-900 dark:text-gray-100 break-words mb-2 font-sans">
+           <p className="kaomoji-safe text-gray-900 dark:text-gray-100 break-words mb-2">
              <Linkify>{post.comment}</Linkify>
            </p>
          ) : null}
@@ -711,7 +711,7 @@ export default function SinglePost({ initialPost, currentUserId }: { initialPost
                             <Link href={`/users/${comment.user.username}`} className="font-bold hover:underline mr-2 text-gray-900 dark:text-gray-100">
                                 {comment.user.username}
                             </Link>
-                            <span className="text-gray-800 dark:text-gray-200 break-words font-sans">
+                            <span className="kaomoji-safe text-gray-800 dark:text-gray-200 break-words">
                                 <Linkify>{comment.text}</Linkify>
                             </span>
                          </div>

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "failed",
-  "failedTests": []
-}

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "failed",
+  "failedTests": []
+}


### PR DESCRIPTION
The application was unable to render certain special Unicode characters and combining marks used in complex Japanese kaomoji (emoticons), resulting in "tofu" (□) characters. This change introduces Noto Sans JP as a web font and updates the global font stack to include comprehensive fallback options for both Japanese text and specialized symbols across different operating systems (macOS, Windows, iOS, Android).

---
*PR created automatically by Jules for task [10308957797838488297](https://jules.google.com/task/10308957797838488297) started by @testuser0123-web*